### PR TITLE
Add intelligent layout system and English bible commentary support

### DIFF
--- a/.env
+++ b/.env
@@ -32,7 +32,7 @@ SEND_EMAIL=false
 FROM_EMAIL_ADDRESS=fake@example.com
 SMTP_PASSWORD=realpasswordgoeshere
 # TO_EMAIL is only used in test runs
-TO_EMAIL_ADDRESS=fake@exmaple.com
+TO_EMAIL_ADDRESS=fake@example.com
 EMAIL_SEND_SUBJECT=The BIEL PDF you requested is attached
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
@@ -51,7 +51,7 @@ RUN_TESTS=false
 ENABLE_ASSET_CACHING=true
 # Caching window of time in which cloned or downloaded resource asset
 # files on disk are considered fresh rather than reacqiring them. In hours.
-ASSET_CACHING_PERIOD=72
+ASSET_CACHING_PERIOD=168
 
 #  * http://localhost:3000 covers requests originating from the case
 #  where 'npm run dev' is invoked to run vite outside Docker. This

--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,14 @@ local-update-deps-prod: local-update-deps-base
 	# FIXME When mypyc build gets fixed we can remove the
 	# --upgradce-package switch.
 	pip-compile ./backend/requirements-prod.in --upgrade-package mypy==0.921
-	# pip-compile --upgrade ./backend/requirements-prod.in
+	# pip-compile --upgrade ./backend/requirements-prod.in --upgrade-package mypy==0.921
 
 .PHONY: local-update-deps-dev
 local-update-deps-dev: local-update-deps-base
 	# FIXME When mypyc build gets fixed we can remove the
 	# --upgradce-package switch.
 	pip-compile ./backend/requirements-dev.in --upgrade-package mypy==0.921
-	# pip-compile --upgrade ./backend/requirements-dev.in
+	# pip-compile --upgrade ./backend/requirements-dev.in --upgrade-package mypy==0.921
 
 .PHONY: local-install-deps-base
 local-install-deps-base: local-update-deps-base
@@ -188,17 +188,72 @@ local-unit-tests:  local-prepare-for-tests
 local-e2e-tests:  local-prepare-for-tests
 	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -vv
 
+# Will execute
+# test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr and test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr_c
 .PHONY: local-smoke-test-with-translation-words
 local-smoke-test-with-translation-words: local-prepare-for-tests
-	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr
 
 .PHONY: local-smoke-test-with-translation-words2
 local-smoke-test-with-translation-words2: local-prepare-for-tests
-	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr_c
 
+# Will execute
+# test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_2c_sl_hr and test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_2c_sl_hr_c
 .PHONY: local-smoke-test-with-translation-words3
 local-smoke-test-with-translation-words3: local-prepare-for-tests
-	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_language_book_order
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_2c_sl_hr
+
+# Will execute
+# test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr and test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr_c
+.PHONY: local-smoke-test-with-translation-words4
+local-smoke-test-with-translation-words4: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr
+
+
+.PHONY: local-smoke-test-with-translation-words5
+local-smoke-test-with-translation-words5: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_kbt_reg_2co_ajg_x_adjtalagbe_reg_2co_pmm_reg_mrk_language_book_order_2c_sl_hr_c
+
+.PHONY: local-smoke-test-with-translation-words6
+local-smoke-test-with-translation-words6: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr_c
+
+.PHONY: local-smoke-test-with-translation-words7
+local-smoke-test-with-translation-words7: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_for_print
+
+.PHONY: local-smoke-test-with-translation-words8
+local-smoke-test-with-translation-words8: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_not_for_print
+
+.PHONY: local-smoke-test-with-translation-words9
+local-smoke-test-with-translation-words9: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_random_non_english_fixtures
+
+.PHONY: local-smoke-test-with-translation-words10
+local-smoke-test-with-translation-words10: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_send_email_with_ar_nav_jud_pdf
+
+.PHONY: local-smoke-test-with-translation-words11
+local-smoke-test-with-translation-words11: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_stream_ar_nav_jud_pdf
+
+.PHONY: local-smoke-test-with-translation-words12
+local-smoke-test-with-translation-words12: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_sr
+
+.PHONY: local-smoke-test-with-translation-words13
+local-smoke-test-with-translation-words13: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_sr_c
+
+.PHONY: local-smoke-test-with-translation-words14
+local-smoke-test-with-translation-words14: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_sw_tw_tit_language_book_order_2c_sl_hr
+
+.PHONY: local-smoke-test-with-translation-words15
+local-smoke-test-with-translation-words15: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_api_randomized_combinatoric
 
 # This is one to run after running local-e2e-tests or any tests which
 # has yielded HTML and PDFs that need to be checked for linking

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,14 @@ local-smoke-test-with-translation-words14: local-prepare-for-tests
 local-smoke-test-with-translation-words15: local-prepare-for-tests
 	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_api_randomized_combinatoric
 
+.PHONY: local-smoke-test-with-translation-words16
+local-smoke-test-with-translation-words16: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_en_bc_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_for_print
+
+.PHONY: local-smoke-test-with-translation-words17
+local-smoke-test-with-translation-words17: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_en_bc_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_not_for_print
+
 # This is one to run after running local-e2e-tests or any tests which
 # has yielded HTML and PDFs that need to be checked for linking
 # correctness.

--- a/backend/document/config.py
+++ b/backend/document/config.py
@@ -86,6 +86,11 @@ class Settings(BaseSettings):
     TN_RESOURCE_TYPES: Sequence[str] = ["tn", "tn-wa"]
     TQ_RESOURCE_TYPES: Sequence[str] = ["tq", "tq-wa"]
     TW_RESOURCE_TYPES: Sequence[str] = ["tw", "tw-wa"]
+    BC_RESOURCE_TYPES: Sequence[str] = ["bc-wa"]
+
+    # fmt: off
+    BC_ARTICLE_URL_FMT_STR: str = "https://content.bibletranslationtools.org/WycliffeAssociates/en_bc/src/branch/master/{}"
+    # fmt: on
 
     def logger(self, name: str) -> logging.Logger:
         """
@@ -219,6 +224,7 @@ class Settings(BaseSettings):
         "tn-wa": "https://content.bibletranslationtools.org/WycliffeAssociates/en_tn",
         "tw-wa": "https://content.bibletranslationtools.org/WycliffeAssociates/en_tw",
         "tq-wa": "https://content.bibletranslationtools.org/WycliffeAssociates/en_tq",
+        "bc-wa": "https://content.bibletranslationtools.org/WycliffeAssociates/en_bc",
     }
 
     ENGLISH_RESOURCE_TYPE_MAP: Mapping[str, str] = {
@@ -227,6 +233,7 @@ class Settings(BaseSettings):
         "tn-wa": "ULB Translation Helps",
         "tq-wa": "ULB Translation Questions",
         "tw-wa": "ULB Translation Words",
+        "bc-wa": "Bible Commentary",
     }
 
     TEMPLATE_PATHS_MAP: Mapping[str, str] = {

--- a/backend/document/config.py
+++ b/backend/document/config.py
@@ -62,7 +62,9 @@ class Settings(BaseSettings):
     OPENING_H3_FMT_STR: str = "<h3>{}"
     OPENING_H3_WITH_ID_FMT_STR: str = '<h3 id="{}-{}">{}'
     TRANSLATION_WORD_ANCHOR_LINK_FMT_STR: str = "[{}](#{}-{})"
+    TRANSLATION_WORD_FMT_STR: str = "{}"
     TRANSLATION_WORD_PREFIX_ANCHOR_LINK_FMT_STR: str = "({}: [{}](#{}-{}))"
+    TRANSLATION_WORD_PREFIX_FMT_STR: str = "({}: {})"
     TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR: str = "[{}](#{}-{}-tn-ch-{}-v-{})"
     # FIXME Tighten up the '.' usage in the following regex
     VERSE_ANCHOR_ID_FMT_STR: str = 'id="(.+?)-ch-(.+?)-v-(.+?)"'
@@ -230,6 +232,7 @@ class Settings(BaseSettings):
     TEMPLATE_PATHS_MAP: Mapping[str, str] = {
         "book_intro": "backend/templates/tn/book_intro_template.md",
         "header_enclosing": "backend/templates/html/header_enclosing.html",
+        "header_compact_enclosing": "backend/templates/html/header_compact_enclosing.html",
         "footer_enclosing": "backend/templates/html/footer_enclosing.html",
         "cover": "backend/templates/html/cover.html",
         "email-html": "backend/templates/html/email.html",
@@ -254,9 +257,6 @@ class Settings(BaseSettings):
     # as a document request parameter so we'll just choose an arbitrary
     # sub-strategy here. This means that we can write code for multiple
     # sub-strategies and choose one to put in play at a time here.
-    DEFAULT_ASSEMBLY_SUBSTRATEGY: model.AssemblySubstrategyEnum = (
-        model.AssemblySubstrategyEnum.VERSE
-    )
 
     # Return a list of the Markdown section titles that our
     # Python-Markdown remove_section_processor extension should remove.

--- a/backend/document/domain/assembly_strategies.py
+++ b/backend/document/domain/assembly_strategies.py
@@ -19,6 +19,7 @@ Architecturally, assembly strategies utilize the Strategy pattern:
 https://github.com/faif/python-patterns/blob/master/patterns/behavioral/strategy.py
 """
 
+import bs4
 import itertools
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -59,6 +60,7 @@ def assembly_factory_for_lang_then_book_strategy(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     assembly_layout_kind: model.AssemblyLayoutEnum,
 ) -> Callable[
     [
@@ -67,6 +69,7 @@ def assembly_factory_for_lang_then_book_strategy(
         Optional[model.TQBook],
         Optional[model.TWBook],
         Optional[model.USFMBook],
+        Optional[model.BCBook],
     ],
     Iterable[model.HtmlContent],
 ]:
@@ -90,6 +93,7 @@ def assembly_factory_for_lang_then_book_strategy(
             bool,  # tq_book_content_unit_exists
             bool,  # tw_book_content_unit_exists
             bool,  # usfm_book_content_unit2_exists
+            bool,  # bc_book_content_unit_exists
             model.AssemblyLayoutEnum,  # assembly_layout_kind
         ],
         Callable[
@@ -99,6 +103,7 @@ def assembly_factory_for_lang_then_book_strategy(
                 Optional[model.TQBook],
                 Optional[model.TWBook],
                 Optional[model.USFMBook],
+                Optional[model.BCBook],
             ],
             Iterable[model.HtmlContent],
         ],
@@ -109,9 +114,29 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
         (
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
             True,
             True,
             True,
@@ -125,6 +150,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
         (
@@ -133,9 +159,614 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
         (
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            True,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
             True,
             True,
             True,
@@ -147,11 +778,31 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             True,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            True,
             False,
             True,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
         (
+            True,
+            True,
+            True,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
             True,
             True,
             True,
@@ -163,102 +814,16 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
-            True,
-            False,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            False,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
             True,
             False,
             False,
-            True,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            False,
-            True,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            False,
-            True,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            False,
-            False,
-            True,
-            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
         (
             True,
             True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
             True,
             True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            True,
-            False,
             False,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
@@ -268,166 +833,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             True,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            True,
             False,
-            True,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            True,
-            False,
-            True,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            True,
-            False,
-            True,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
-            True,
-            False,
-            True,
-            True,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            True,
-            True,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            True,
-            True,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            False,
-            True,
-            True,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
-            True,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
-            False,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            False,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            False,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            False,
-            False,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
-            True,
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
-        (
-            True,
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
-        (
-            True,
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
-        (
-            True,
-            True,
-            False,
-            True,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
@@ -437,6 +843,16 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
         (
@@ -444,6 +860,16 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
@@ -453,6 +879,25 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
         (
@@ -460,6 +905,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             True,
+            False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_usfm_tq_tw_for_lang_then_book_2c_sl_hr,
@@ -469,6 +915,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_tq_tw_for_lang_then_book_2c_sl_hr,
         (
@@ -476,6 +923,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_usfm_tq_tw_for_lang_then_book_1c,
@@ -485,6 +933,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_tq_tw_for_lang_then_book_1c_c,
         (
@@ -492,6 +941,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             True,
+            False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_usfm_tw_for_lang_then_book_2c_sl_hr,
@@ -501,6 +951,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_tw_for_lang_then_book_2c_sl_hr,
         (
@@ -508,6 +959,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_usfm_tw_for_lang_then_book_1c,
@@ -517,6 +969,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_tw_for_lang_then_book_1c_c,
         (
@@ -525,12 +978,23 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
         (
             True,
             True,
             True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            False,
             False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
@@ -541,6 +1005,16 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
         (
@@ -549,12 +1023,32 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            True,
+            False,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
         (
             True,
             False,
             True,
+            False,
             False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
@@ -565,6 +1059,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_tq_for_lang_then_book_2c_sl_hr,
         (
@@ -573,6 +1068,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_usfm_tq_for_lang_then_book_1c,
         (
@@ -581,11 +1077,13 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_tq_for_lang_then_book_1c,
         (
             True,
             True,
+            False,
             False,
             False,
             False,
@@ -597,11 +1095,31 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
         (
             True,
             True,
+            False,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
             False,
             False,
             False,
@@ -613,6 +1131,25 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
         (
@@ -621,6 +1158,7 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tn_as_iterator_for_lang_then_book,
         (
@@ -628,6 +1166,52 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            True,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            True,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            False,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            False,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_lang_then_book,
@@ -637,20 +1221,14 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             False,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_tn_as_iterator_for_lang_then_book,
-        (
-            False,
             True,
-            False,
-            True,
-            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_lang_then_book,
         (
             False,
             True,
             True,
+            False,
             False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
@@ -661,6 +1239,25 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_lang_then_book,
+        (
+            False,
+            True,
+            True,
+            False,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_lang_then_book,
         (
@@ -668,6 +1265,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tq_tw_for_lang_then_book,
@@ -677,6 +1275,25 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tq_tw_for_lang_then_book,
+        (
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tq_tw_for_lang_then_book,
+        (
+            False,
+            False,
+            True,
+            True,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tq_tw_for_lang_then_book,
         (
@@ -684,6 +1301,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tw_as_iterator_for_lang_then_book,
@@ -693,12 +1311,14 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             True,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tw_as_iterator_for_lang_then_book,
         (
             False,
             False,
             True,
+            False,
             False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
@@ -709,10 +1329,12 @@ def assembly_factory_for_lang_then_book_strategy(
             True,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tq_as_iterator_for_lang_then_book,
         (
             True,
+            False,
             False,
             False,
             False,
@@ -725,10 +1347,12 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr,
         (
             True,
+            False,
             False,
             False,
             False,
@@ -741,6 +1365,7 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_by_usfm_as_iterator_for_lang_then_book_1c_c,
         (
@@ -749,11 +1374,13 @@ def assembly_factory_for_lang_then_book_strategy(
             False,
             False,
             False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tn_as_iterator_for_lang_then_book,
         (
             False,
             True,
+            False,
             False,
             False,
             False,
@@ -785,6 +1412,7 @@ def assembly_factory_for_lang_then_book_strategy(
             tq_book_content_unit is not None,
             tw_book_content_unit is not None,
             usfm_book_content_unit2 is not None,
+            bc_book_content_unit is not None,
             assembly_layout_kind,
         )
     ]
@@ -795,6 +1423,7 @@ def assembly_factory_for_book_then_lang_strategy(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
     assembly_layout_kind: model.AssemblyLayoutEnum,
 ) -> Callable[
     [
@@ -802,6 +1431,7 @@ def assembly_factory_for_book_then_lang_strategy(
         Sequence[model.TNBook],
         Sequence[model.TQBook],
         Sequence[model.TWBook],
+        Sequence[model.BCBook],
     ],
     Iterable[model.HtmlContent],
 ]:
@@ -824,6 +1454,7 @@ def assembly_factory_for_book_then_lang_strategy(
             bool,  # tn_book_content_units is non-empty
             bool,  # tq_book_content_units is non-empty
             bool,  # tw_book_content_units is non-empty
+            bool,  # bc_book_content_units is non-empty
             model.AssemblyLayoutEnum,  # assembly_layout_kind
         ],
         Callable[
@@ -832,6 +1463,7 @@ def assembly_factory_for_book_then_lang_strategy(
                 Sequence[model.TNBook],
                 Sequence[model.TQBook],
                 Sequence[model.TWBook],
+                Sequence[model.BCBook],
             ],
             Iterable[model.HtmlContent],
         ],
@@ -841,9 +1473,27 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
         (
+            True,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
             True,
             True,
             True,
@@ -855,9 +1505,27 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
         (
+            True,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
             True,
             True,
             True,
@@ -869,51 +1537,19 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             True,
             True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
-        (
-            True,
-            True,
-            True,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
-        (
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
-        (
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
-        (
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
-        (
-            True,
-            True,
-            True,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
-        (
-            True,
-            True,
-            True,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c,
         (
+            True,
+            True,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
             True,
             True,
             True,
@@ -923,46 +1559,13 @@ def assembly_factory_for_book_then_lang_strategy(
         (
             True,
             True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
-        (
             True,
             True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
-        (
-            True,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
-        (
-            True,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
-        (
-            True,
-            True,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
-        (
-            True,
-            True,
-            False,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
         (
+            True,
             True,
             True,
             False,
@@ -972,11 +1575,29 @@ def assembly_factory_for_book_then_lang_strategy(
         (
             True,
             True,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            True,
             False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
         (
+            True,
+            True,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
             True,
             True,
             False,
@@ -986,11 +1607,29 @@ def assembly_factory_for_book_then_lang_strategy(
         (
             True,
             True,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            True,
             False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
         (
+            True,
+            True,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
             True,
             True,
             False,
@@ -1000,13 +1639,231 @@ def assembly_factory_for_book_then_lang_strategy(
         (
             True,
             True,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            True,
+            True,
             False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
         (
             True,
+            True,
+            True,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            True,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            True,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
             True,
             True,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
@@ -1016,11 +1873,29 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
         (
             True,
             False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            True,
             True,
             True,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
@@ -1030,11 +1905,29 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
         (
             True,
             False,
+            True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            False,
+            True,
             True,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN,
@@ -1044,12 +1937,22 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
         (
             True,
             False,
             True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            False,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
@@ -1058,12 +1961,30 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
         (
             True,
             False,
             True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
@@ -1072,12 +1993,30 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            True,
+            False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
         (
             True,
             False,
             True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c,
@@ -1086,10 +2025,132 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            False,
+            True,
+            False,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
         (
             True,
+            False,
+            True,
+            False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            False,
+            False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            False,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            False,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
             False,
             False,
             True,
@@ -1099,53 +2160,21 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             False,
             False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
-        (
-            True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
-        (
-            True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
-        (
-            True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN,
-        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
-        (
-            True,
-            False,
-            False,
-            True,
-            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
-        (
-            True,
-            False,
-            False,
-            False,
-            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
-        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
-        (
-            True,
-            False,
             False,
             False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
         (
             True,
+            False,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr,
+        (
+            True,
+            False,
             False,
             False,
             False,
@@ -1156,10 +2185,28 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
+            False,
+            False,
+            False,
             model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
         (
             True,
+            False,
+            False,
+            False,
+            True,
+            model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr,
+        (
+            True,
+            False,
             False,
             False,
             False,
@@ -1170,10 +2217,36 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c,
+        (
+            True,
+            False,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
+        (
+            True,
+            False,
+            False,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_usfm_as_iterator_for_book_then_lang_1c_c,
         (
             False,
+            True,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_book_then_lang,
+        (
+            False,
+            True,
             True,
             True,
             True,
@@ -1184,12 +2257,22 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_book_then_lang_c,
         (
             False,
             True,
             True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_book_then_lang_c,
+        (
+            False,
+            True,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tn_as_iterator_for_book_then_lang,
@@ -1198,12 +2281,38 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_book_then_lang,
+        (
+            False,
+            True,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_book_then_lang_c,
+        (
+            False,
+            True,
+            True,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_book_then_lang_c,
         (
             False,
             True,
             False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_book_then_lang,
+        (
+            False,
+            True,
+            False,
+            True,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tn_as_iterator_for_book_then_lang,
@@ -1212,11 +2321,21 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             False,
             True,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_book_then_lang_c,
         (
             False,
             True,
+            False,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_book_then_lang_c,
+        (
+            False,
+            True,
+            False,
             False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
@@ -1226,11 +2345,37 @@ def assembly_factory_for_book_then_lang_strategy(
             True,
             False,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tn_as_iterator_for_book_then_lang,
+        (
+            False,
+            True,
+            False,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tn_as_iterator_for_book_then_lang_c,
+        (
+            False,
+            True,
+            False,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tn_as_iterator_for_book_then_lang_c,
         (
             False,
             False,
+            True,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tq_as_iterator_for_book_then_lang,
+        (
+            False,
+            False,
+            True,
             True,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN,
@@ -1240,12 +2385,22 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             True,
+            False,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tq_as_iterator_for_book_then_lang_c,
         (
             False,
             False,
             True,
+            True,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tq_as_iterator_for_book_then_lang_c,
+        (
+            False,
+            False,
+            True,
+            False,
             False,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tq_as_iterator_for_book_then_lang,
@@ -1254,12 +2409,38 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             True,
             False,
+            True,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tq_as_iterator_for_book_then_lang,
+        (
+            False,
+            False,
+            True,
+            False,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tq_as_iterator_for_book_then_lang_c,
+        (
+            False,
+            False,
+            True,
+            False,
+            True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tq_as_iterator_for_book_then_lang_c,
         (
             False,
             False,
             False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN,
+        ): assemble_tw_as_iterator_for_book_then_lang,
+        (
+            False,
+            False,
+            False,
+            True,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN,
         ): assemble_tw_as_iterator_for_book_then_lang,
@@ -1267,6 +2448,15 @@ def assembly_factory_for_book_then_lang_strategy(
             False,
             False,
             False,
+            True,
+            False,
+            model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+        ): assemble_tw_as_iterator_for_book_then_lang,
+        (
+            False,
+            False,
+            False,
+            True,
             True,
             model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
         ): assemble_tw_as_iterator_for_book_then_lang,
@@ -1280,6 +2470,7 @@ def assembly_factory_for_book_then_lang_strategy(
             True if tn_book_content_units else False,
             True if tq_book_content_units else False,
             True if tw_book_content_units else False,
+            True if bc_book_content_units else False,
             assembly_layout_kind,
         )
     ]
@@ -1341,6 +2532,9 @@ def assemble_content_by_lang_then_book(
             usfm_book_content_unit2: Optional[
                 model.USFMBook
             ] = second_usfm_book_content_unit(book_content_units_)
+            bc_book_content_unit_: Optional[model.BCBook] = bc_book_content_unit(
+                book_content_units_
+            )
 
             # We've got the resources, now we can use the sub-strategy factory
             # method to choose the right function to use from here on out.
@@ -1350,6 +2544,7 @@ def assemble_content_by_lang_then_book(
                 tq_book_content_unit_,
                 tw_book_content_unit_,
                 usfm_book_content_unit2,
+                bc_book_content_unit_,
                 assembly_layout_kind,
             )
 
@@ -1363,6 +2558,7 @@ def assemble_content_by_lang_then_book(
                 tq_book_content_unit_,
                 tw_book_content_unit_,
                 usfm_book_content_unit2,
+                bc_book_content_unit_,
             )
 
 
@@ -1411,6 +2607,11 @@ def assemble_content_by_book_then_lang(
             for book_content_unit in book_content_units_grouped_by_book
             if isinstance(book_content_unit, model.TWBook)
         ]
+        bc_book_content_units: Sequence[model.BCBook] = [
+            book_content_unit
+            for book_content_unit in book_content_units_grouped_by_book
+            if isinstance(book_content_unit, model.BCBook)
+        ]
 
         # We've got the resources, now we can use the sub-strategy factory
         # method to choose the right function to use from here on out.
@@ -1420,6 +2621,7 @@ def assemble_content_by_book_then_lang(
                 tn_book_content_units,
                 tq_book_content_units,
                 tw_book_content_units,
+                bc_book_content_units,
                 assembly_layout_kind,
             )
         )
@@ -1436,6 +2638,7 @@ def assemble_content_by_book_then_lang(
             tn_book_content_units,
             tq_book_content_units,
             tw_book_content_units,
+            bc_book_content_units,
         )
 
 
@@ -1503,6 +2706,7 @@ def assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_fmt_str: str = settings.RESOURCE_TYPE_NAME_FMT_STR,
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
@@ -1545,6 +2749,8 @@ def assemble_by_usfm_as_iterator_for_lang_then_book_2c_sl_hr(
                 yield chapter_intro(tn_book_content_unit, chapter_num)
 
                 tn_verses = verses_for_chapter_tn(tn_book_content_unit, chapter_num)
+            if bc_book_content_unit:
+                yield chapter_commentary(bc_book_content_unit, chapter_num)
             if tq_book_content_unit:
                 tq_verses = verses_for_chapter_tq(tq_book_content_unit, chapter_num)
 
@@ -1672,6 +2878,7 @@ def assemble_by_usfm_as_iterator_for_lang_then_book_1c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_fmt_str: str = settings.RESOURCE_TYPE_NAME_FMT_STR,
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
@@ -1708,8 +2915,9 @@ def assemble_by_usfm_as_iterator_for_lang_then_book_1c(
             if tn_book_content_unit:
                 # Add the translation notes chapter intro.
                 yield chapter_intro(tn_book_content_unit, chapter_num)
-
                 tn_verses = verses_for_chapter_tn(tn_book_content_unit, chapter_num)
+            if bc_book_content_unit:
+                yield chapter_commentary(bc_book_content_unit, chapter_num)
             if tq_book_content_unit:
                 tq_verses = verses_for_chapter_tq(tq_book_content_unit, chapter_num)
 
@@ -1830,6 +3038,7 @@ def assemble_by_usfm_as_iterator_for_lang_then_book_1c_c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_fmt_str: str = settings.RESOURCE_TYPE_NAME_FMT_STR,
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
@@ -1868,6 +3077,8 @@ def assemble_by_usfm_as_iterator_for_lang_then_book_1c_c(
                 yield chapter_intro(tn_book_content_unit, chapter_num)
 
                 tn_verses = verses_for_chapter_tn(tn_book_content_unit, chapter_num)
+            if bc_book_content_unit:
+                yield chapter_commentary(bc_book_content_unit, chapter_num)
             if tq_book_content_unit:
                 tq_verses = verses_for_chapter_tq(tq_book_content_unit, chapter_num)
 
@@ -1990,6 +3201,7 @@ def assemble_usfm_tq_tw_for_lang_then_book_2c_sl_hr(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2070,6 +3282,7 @@ def assemble_usfm_tq_tw_for_lang_then_book_1c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     # html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2143,6 +3356,7 @@ def assemble_usfm_tq_tw_for_lang_then_book_1c_c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     # html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2218,6 +3432,7 @@ def assemble_usfm_tw_for_lang_then_book_2c_sl_hr(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2288,6 +3503,7 @@ def assemble_usfm_tw_for_lang_then_book_1c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
 ) -> Iterable[model.HtmlContent]:
@@ -2346,6 +3562,7 @@ def assemble_usfm_tw_for_lang_then_book_1c_c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
 ) -> Iterable[model.HtmlContent]:
@@ -2406,6 +3623,7 @@ def assemble_usfm_tq_for_lang_then_book_2c_sl_hr(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2474,6 +3692,7 @@ def assemble_usfm_tq_for_lang_then_book_1c(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
 ) -> Iterable[model.HtmlContent]:
@@ -2530,6 +3749,7 @@ def assemble_tn_as_iterator_for_lang_then_book(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     chapter_header_fmt_str: str = settings.CHAPTER_HEADER_FMT_STR,
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     book_numbers: Mapping[str, str] = bible_books.BOOK_NUMBERS,
@@ -2559,6 +3779,10 @@ def assemble_tn_as_iterator_for_lang_then_book(
 
             # Add the translation notes chapter intro.
             yield chapter_intro(tn_book_content_unit, chapter_num)
+
+            if bc_book_content_unit:
+                # Add the chapter commentary.
+                yield chapter_commentary(bc_book_content_unit, chapter_num)
 
             tn_verses = verses_for_chapter_tn(tn_book_content_unit, chapter_num)
             tq_verses = None
@@ -2612,6 +3836,7 @@ def assemble_tq_as_iterator_for_lang_then_book(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     chapter_header_fmt_str: str = settings.CHAPTER_HEADER_FMT_STR,
     book_numbers: Mapping[str, str] = bible_books.BOOK_NUMBERS,
     num_zeros: int = NUM_ZEROS,
@@ -2621,6 +3846,10 @@ def assemble_tq_as_iterator_for_lang_then_book(
 
     if tq_book_content_unit:
         for chapter_num in tq_book_content_unit.chapters:
+            if bc_book_content_unit:
+                # Add chapter commentary.
+                yield chapter_commentary(bc_book_content_unit, chapter_num)
+
             # How to get chapter heading for Translation questions when there is
             # not USFM requested? For now we'll use non-localized chapter heading.
             # Add in the USFM chapter heading.
@@ -2656,6 +3885,7 @@ def assemble_tq_tw_for_lang_then_book(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
     chapter_header_fmt_str: str = settings.CHAPTER_HEADER_FMT_STR,
     book_numbers: Mapping[str, str] = bible_books.BOOK_NUMBERS,
     num_zeros: int = NUM_ZEROS,
@@ -2664,8 +3894,12 @@ def assemble_tq_tw_for_lang_then_book(
     Construct the HTML for a 'by verse' strategy wherein only TQ and
     TW exists.
     """
+
     if tq_book_content_unit:
         for chapter_num in tq_book_content_unit.chapters:
+            if bc_book_content_unit:
+                # Add chapter commmentary.
+                yield chapter_commentary(bc_book_content_unit, chapter_num)
             # How to get chapter heading for Translation questions when there is
             # not USFM requested? For now we'll use non-localized chapter heading.
             # Add in the USFM chapter heading.
@@ -2715,6 +3949,7 @@ def assemble_tw_as_iterator_for_lang_then_book(
     tq_book_content_unit: Optional[model.TQBook],
     tw_book_content_unit: Optional[model.TWBook],
     usfm_book_content_unit2: Optional[model.USFMBook],
+    bc_book_content_unit: Optional[model.BCBook],
 ) -> Iterable[model.HtmlContent]:
     """Construct the HTML for a 'by verse' strategy wherein only TW exists."""
     if tw_book_content_unit:
@@ -2733,6 +3968,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2752,6 +3988,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_2c_sl_hr(
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
     tw_book_content_units = sorted(tw_book_content_units, key=key)
+    bc_book_content_units = sorted(bc_book_content_units, key=key)
 
     # Add book intros for each tn_book_content_unit
     for tn_book_content_unit in tn_book_content_units:
@@ -2911,6 +4148,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
     html_row_begin: str = settings.HTML_ROW_BEGIN,
@@ -2929,6 +4167,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr(
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
     tw_book_content_units = sorted(tw_book_content_units, key=key)
+    bc_book_content_units = sorted(bc_book_content_units, key=key)
 
     # Add book intros for each tn_book_content_unit
     for tn_book_content_unit in tn_book_content_units:
@@ -2956,6 +4195,12 @@ def assemble_usfm_as_iterator_for_book_then_lang_2c_sl_sr(
         for tn_book_content_unit2 in tn_book_content_units:
             # Add the translation notes chapter intro.
             yield model.HtmlContent(chapter_intro(tn_book_content_unit2, chapter_num))
+
+        for bc_book_content_unit in bc_book_content_units:
+            # Add the chapter commentary.
+            yield model.HtmlContent(
+                chapter_commentary(bc_book_content_unit, chapter_num)
+            )
 
         # Use the usfm_book_content_unit that has the most verses for
         # this chapter_num chapter as a verse_num pump.
@@ -3083,6 +4328,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_1c(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
 ) -> Iterable[model.HtmlContent]:
@@ -3143,6 +4389,12 @@ def assemble_usfm_as_iterator_for_book_then_lang_1c(
         for tn_book_content_unit2 in tn_book_content_units:
             # Add the translation notes chapter intro.
             yield model.HtmlContent(chapter_intro(tn_book_content_unit2, chapter_num))
+
+        for bc_book_content_unit in bc_book_content_units:
+            # Add the chapter commentary.
+            yield model.HtmlContent(
+                chapter_commentary(bc_book_content_unit, chapter_num)
+            )
 
         # Use the usfm_book_content_unit that has the most verses for
         # this chapter_num chapter as a verse_num pump.
@@ -3265,6 +4517,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_1c_c(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
     resource_type_name_with_ref_fmt_str: str = settings.RESOURCE_TYPE_NAME_WITH_REF_FMT_STR,
     footnotes_heading: model.HtmlContent = settings.FOOTNOTES_HEADING,
 ) -> Iterable[model.HtmlContent]:
@@ -3297,7 +4550,7 @@ def assemble_usfm_as_iterator_for_book_then_lang_1c_c(
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
     tw_book_content_units = sorted(tw_book_content_units, key=key)
-    # ta_book_content_units = sorted(ta_book_content_units, key=key)
+    bc_book_content_units = sorted(bc_book_content_units, key=key)
 
     # Add book intros for each tn_book_content_unit
     for tn_book_content_unit in tn_book_content_units:
@@ -3326,6 +4579,12 @@ def assemble_usfm_as_iterator_for_book_then_lang_1c_c(
         for tn_book_content_unit2 in tn_book_content_units:
             # Add the translation notes chapter intro.
             yield model.HtmlContent(chapter_intro(tn_book_content_unit2, chapter_num))
+
+        for bc_book_content_unit in bc_book_content_units:
+            # Add the commentary for chapter.
+            yield model.HtmlContent(
+                chapter_commentary(bc_book_content_unit, chapter_num)
+            )
 
         # Use the usfm_book_content_unit that has the most verses for
         # this chapter_num chapter as a verse_num pump.
@@ -3413,6 +4672,7 @@ def assemble_tn_as_iterator_for_book_then_lang(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
 ) -> Iterable[model.HtmlContent]:
     """
     Construct the HTML for a 'by verse' strategy wherein at least
@@ -3433,6 +4693,7 @@ def assemble_tn_as_iterator_for_book_then_lang(
     """
     # Sort resources by language
     key = lambda resource: resource.lang_code
+    # FIXME Do we need to sort anthing other than tn_book_content_unites?
     usfm_book_content_units = sorted(usfm_book_content_units, key=key)
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
@@ -3534,6 +4795,7 @@ def assemble_tn_as_iterator_for_book_then_lang_c(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
 ) -> Iterable[model.HtmlContent]:
     """
     Construct the HTML for a 'by verse' strategy wherein at least
@@ -3554,11 +4816,12 @@ def assemble_tn_as_iterator_for_book_then_lang_c(
     """
     # Sort resources by language
     key = lambda resource: resource.lang_code
+    # FIXME Do we need to sort anything other than tn_book_content_units?
     usfm_book_content_units = sorted(usfm_book_content_units, key=key)
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
     tw_book_content_units = sorted(tw_book_content_units, key=key)
-    # ta_book_content_units = sorted(ta_book_content_units, key=key)
+    bc_book_content_units = sorted(bc_book_content_units, key=key)
 
     # Add book intros for each tn_book_content_unit
     for tn_book_content_unit in tn_book_content_units:
@@ -3579,6 +4842,10 @@ def assemble_tn_as_iterator_for_book_then_lang_c(
         for tn_book_content_unit in tn_book_content_units:
             # Add the translation notes chapter intro.
             yield from chapter_intro(tn_book_content_unit, chapter_num)
+
+        for bc_book_content_unit in bc_book_content_units:
+            # Add chapter commentary.
+            yield from chapter_commentary(bc_book_content_unit, chapter_num)
 
         # Use the tn_book_content_unit that has the most verses for
         # this chapter_num chapter as a verse_num pump.
@@ -3628,6 +4895,7 @@ def assemble_tq_as_iterator_for_book_then_lang(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
 ) -> Iterable[model.HtmlContent]:
     """
     Construct the HTML for a 'by verse' strategy wherein at least
@@ -3717,6 +4985,7 @@ def assemble_tq_as_iterator_for_book_then_lang_c(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
 ) -> Iterable[model.HtmlContent]:
     """
     Construct the HTML for a 'by verse' strategy wherein at least
@@ -3725,11 +4994,12 @@ def assemble_tq_as_iterator_for_book_then_lang_c(
 
     # Sort resources by language
     key = lambda resource: resource.lang_code
+    # FIXME Do we need to sort anything but tq and down here?
     usfm_book_content_units = sorted(usfm_book_content_units, key=key)
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
     tw_book_content_units = sorted(tw_book_content_units, key=key)
-    # ta_book_content_units = sorted(ta_book_content_units, key=key)
+    bc_book_content_units = sorted(bc_book_content_units, key=key)
 
     # Use the tq_book_content_unit that has the most chapters as a
     # chapter_num pump.
@@ -3741,6 +5011,10 @@ def assemble_tq_as_iterator_for_book_then_lang_c(
     )
     for chapter_num in tq_with_most_chapters.chapters.keys():
         yield model.HtmlContent("Chapter {}".format(chapter_num))
+
+        for bc_book_content_unit in bc_book_content_units:
+            # Add chapter commentary
+            yield chapter_commentary(bc_book_content_unit, chapter_num)
 
         # Use the tn_book_content_unit that has the most verses for
         # this chapter_num chapter as a verse_num pump.
@@ -3779,16 +5053,19 @@ def assemble_tw_as_iterator_for_book_then_lang(
     tn_book_content_units: Sequence[model.TNBook],
     tq_book_content_units: Sequence[model.TQBook],
     tw_book_content_units: Sequence[model.TWBook],
+    bc_book_content_units: Sequence[model.BCBook],
 ) -> Iterable[model.HtmlContent]:
     """Construct the HTML for a only TW."""
 
     # Sort resources by language
     key = lambda resource: resource.lang_code
+    # FIXME Do we need to sort anything other than
+    # tw_book_content_units here?
     usfm_book_content_units = sorted(usfm_book_content_units, key=key)
     tn_book_content_units = sorted(tn_book_content_units, key=key)
     tq_book_content_units = sorted(tq_book_content_units, key=key)
     tw_book_content_units = sorted(tw_book_content_units, key=key)
-    # ta_book_content_units = sorted(ta_book_content_units, key=key)
+    bc_book_content_units = sorted(bc_book_content_units, key=key)
 
     # Add the translation word definitions
     for tw_book_content_unit in tw_book_content_units:
@@ -3917,6 +5194,21 @@ def tq_book_content_unit(
     return tq_book_content_units[0] if tq_book_content_units else None
 
 
+def bc_book_content_unit(
+    book_content_units: Sequence[model.BookContent],
+) -> Optional[model.BCBook]:
+    """
+    Return the BCBook instance, if any, contained in book_content_units,
+    else return None.
+    """
+    bc_book_content_units = [
+        book_content_unit
+        for book_content_unit in book_content_units
+        if isinstance(book_content_unit, model.BCBook)
+    ]
+    return bc_book_content_units[0] if bc_book_content_units else None
+
+
 def adjust_book_intro_headings(book_intro: str) -> model.HtmlContent:
     """Change levels on headings."""
     # Move the H2 out of the way, we'll deal with it last.
@@ -3938,6 +5230,18 @@ def adjust_chapter_intro_headings(chapter_intro: str) -> model.HtmlContent:
     return model.HtmlContent(re.sub(H6, H5, chapter_intro))
 
 
+def adjust_chapter_commentary_headings(chapter_commentary: str) -> model.HtmlContent:
+    """Change levels on headings."""
+    # logger.debug("commentary parser: %s", parser)
+    # Move the H4 out of the way, we'll deal with it last.
+    chapter_commentary = re.sub(H4, H6, chapter_commentary)
+    chapter_commentary = re.sub(H3, H4, chapter_commentary)
+    chapter_commentary = re.sub(H1, H3, chapter_commentary)
+    chapter_commentary = re.sub(H2, H4, chapter_commentary)
+    # Now adjust the temporary H6s.
+    return model.HtmlContent(re.sub(H6, H5, chapter_commentary))
+
+
 def chapter_intro(
     tn_book_content_unit: model.TNBook, chapter_num: int
 ) -> model.HtmlContent:
@@ -3946,12 +5250,18 @@ def chapter_intro(
         chapter_intro = tn_book_content_unit.chapters[chapter_num].intro_html
     else:
         chapter_intro = model.HtmlContent("")
-    # NOTE I am not sure that the 'Links:' section of chapter
-    # intro makes sense anymore with the way documents
-    # are interleaved.
-    # Remove the Links: section of the markdown.
-    # chapter_intro = markdown_utils.remove_md_section(chapter_intro, "Links:")
     return adjust_chapter_intro_headings(chapter_intro)
+
+
+def chapter_commentary(
+    bc_book_content_unit: model.BCBook, chapter_num: int
+) -> model.HtmlContent:
+    """Get the chapter commentary."""
+    if bc_book_content_unit and chapter_num in bc_book_content_unit.chapters:
+        chapter_commentary = bc_book_content_unit.chapters[chapter_num].commentary
+    else:
+        chapter_commentary = model.HtmlContent("")
+    return adjust_chapter_commentary_headings(chapter_commentary)
 
 
 def format_tn_verse(

--- a/backend/document/domain/model.py
+++ b/backend/document/domain/model.py
@@ -62,8 +62,70 @@ class AssemblyStrategyEnum(str, Enum):
     AssemblySubstrategyEnum. The sky is the limit.
     """
 
-    LANGUAGE_BOOK_ORDER = "language_book_order"
-    BOOK_LANGUAGE_ORDER = "book_language_order"
+    LANGUAGE_BOOK_ORDER = "lbo"
+    BOOK_LANGUAGE_ORDER = "blo"
+
+
+@final
+class AssemblyLayoutEnum(str, Enum):
+    """
+    A enum used by the assembly_strategies module to know how
+    to layout the content.
+
+    We can have N such layouts and each can be completely
+    arbitrary, simply based on the desires of content designers.
+
+    Said another way: the enum is just a name that is arbitrarily
+    chosen to be compact but adequate to express the type of layout
+    that is to be accomplished in the HTML document (prior to conversion
+    to PDF).
+
+    Layouts:
+
+    * ONE_COLUMN
+      One column verse and associated content interleave
+
+    * TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT
+      Two columns, with scripture on the left and its associated helps
+      on the right. This layout causes excessive whitespace on the
+      left side because helps are much longer than verses typically.
+
+    * TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT
+      Two columns, with scripture on the left and a different
+      scripture on the right. Obviously only applicable when at least
+      two languages have been chosen. This layout has less whitespace
+      than TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT because verses on
+      the left are typically about the same size as verses on the right
+      and helps are shown vertically spanning the whole horizontal space
+      after each verse.
+
+    * ONE_COLUMN_COMPACT
+      This layout minimizes whitespace in a one column layout so as to
+      be appropriate for printing to paper.
+
+    * TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT
+      This layout minimizes whitespace by using
+      TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT layout but with a different
+      CSS styling that results in less whitespace.
+
+    * TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT
+      This layout minimizes whitespace by using
+      TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT layout but with a
+      different CSS styling that results in less whitespace.
+    """
+
+    ONE_COLUMN = "1c"
+    ONE_COLUMN_COMPACT = "1c_c"
+    TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT = "2c_sl_hr"
+    # fmt: off
+    TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT = "2c_sl_hr_c"
+    # NOTE The next two layouts would only make sense
+    # with an AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER assembly
+    # strategy when more than one language is chosen for the same
+    # book.
+    TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT = "2c_sl_sr"
+    TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT = "2c_sl_sr_c"
+    # fmt: on
 
 
 @final
@@ -78,42 +140,27 @@ class DocumentRequest(BaseModel):
 
     email_address: Optional[EmailStr]
     assembly_strategy_kind: AssemblyStrategyEnum
+    # NOTE For testing we want to exercise various layouts, thus we
+    # make this attribute Optional so that we can specify it in unit
+    # tests if desired. But the normal case is to set
+    # assembly_layout_kind to None in a document request if we are
+    # manually coding up a document request instance to send to the
+    # API. If you go this latter route, say to use the API in a
+    # different context than interacting with the UI then the onus is
+    # on you as the developer to choose an assembly_layout_kind that
+    # makes sense given the document request you have instantiated.
+    # The system knows which make sense and which do not given your
+    # document request and if you choose one that does not make sense
+    # then you'll get an exception on purpose.
+    assembly_layout_kind: Optional[AssemblyLayoutEnum]
+    # The user can choose whether the result should be formatted to
+    # print. When the user selects yes/True to format for print
+    # then we'll choose a compact layout that makes sense for their
+    # document request. This happens in
+    # document_generator.select_assembly_layout_kind if
+    # assembly_layout_kind is None in the document request.
+    layout_for_print: bool
     resource_requests: Sequence[ResourceRequest]
-
-
-@final
-class AssemblySubstrategyEnum(str, Enum):
-    """
-    A sub-strategy enum signals which interleaving sub-strategy
-    to use.
-    E.g., If the high level interleaving strategy LANGUAGE_BOOK_ORDER
-    has been chosen then inside the language and book interleaving
-    loop the sub-strategy will be signaled by a value from this
-    AssemblySubstrategyEnum.
-
-    We can have N such sub-strategies and each can be completely
-    arbitrary, simply based on the desires of content designers.
-
-    Said another way: the enum is just a name that is arbitrarily
-    chosen to be compact but adequate to express the type of interleaving
-    that is to be accomplished in the HTML document (prior to conversion
-    to PDf).
-
-    There is currently one assembly sub-strategy kind to choose from:
-
-    * VERSE
-      - cause a verse's worth of each resource's content to be interleaved.
-
-    NOTE
-    We could later add others. As an arbitrary example, perhaps we'd
-    want a sub-strategy that did verse-level interleaving for USFM and
-    TN, but chapter level interleaving for TQ or if not chapter then
-    some totally arbitrary interleaving or organization. Basically,
-    the enum values are just used to select a particular assembly
-    sub-strategy, whatever it is.
-    """
-
-    VERSE = "VERSE"
 
 
 @final

--- a/backend/document/domain/model.py
+++ b/backend/document/domain/model.py
@@ -197,9 +197,9 @@ class ResourceLookupDto(BaseModel):
 @final
 class FinishedDocumentDetails(BaseModel):
     """
-    Pydanctic model that we use as a return value to send back via
-    Fastapi to the client. For now it just contains the finished
-    dcocument filepath on disk.
+    Pydantic model that we use as a return value to send back via
+    FastAPI to the client. For now it just contains the finished
+    document filepath on disk.
     """
 
     finished_document_request_key: Optional[str]
@@ -298,6 +298,30 @@ class TWBook(BaseModel):
 
 
 @final
+class BCChapter(BaseModel):
+    """
+    A class to hold a mapping of verse references to bible
+    commentary HTML content.
+    """
+
+    commentary: HtmlContent
+
+
+@final
+class BCBook(BaseModel):
+    """
+    A class to hold a mapping of chapter numbers to translation questions
+    HTML content.
+    """
+
+    lang_code: str
+    lang_name: str
+    resource_code: str
+    resource_type_name: str
+    chapters: dict[ChapterNum, BCChapter]
+
+
+@final
 class USFMChapter(BaseModel):
     """
     A class to hold the USFM converted to HTML content for a chapter
@@ -328,7 +352,7 @@ class USFMBook(BaseModel):
     chapters: dict[ChapterNum, USFMChapter]
 
 
-BookContent = Union[USFMBook, TNBook, TQBook, TWBook]
+BookContent = Union[USFMBook, TNBook, TQBook, TWBook, BCBook]
 
 
 @final

--- a/backend/document/domain/parsing.py
+++ b/backend/document/domain/parsing.py
@@ -16,6 +16,7 @@ from document.config import settings
 from document.domain import bible_books, model
 from document.markdown_extensions import (
     link_transformer_preprocessor,
+    link_print_transformer_preprocessor,
     remove_section_preprocessor,
 )
 from document.utils import file_utils, html_parsing_utils, tw_utils
@@ -191,6 +192,7 @@ def book_content(
     resource_lookup_dto: model.ResourceLookupDto,
     resource_dir: str,
     resource_requests: Sequence[model.ResourceRequest],
+    layout_for_print: bool,
     usfm_resource_types: Sequence[str] = settings.USFM_RESOURCE_TYPES,
     tn_resource_types: Sequence[str] = settings.TN_RESOURCE_TYPES,
     tq_resource_types: Sequence[str] = settings.TQ_RESOURCE_TYPES,
@@ -200,27 +202,36 @@ def book_content(
     book_content: model.BookContent
     if resource_lookup_dto.resource_type in usfm_resource_types:
         book_content = usfm_book_content(
-            resource_lookup_dto, resource_dir, resource_requests
+            resource_lookup_dto, resource_dir, resource_requests, layout_for_print
         )
     elif resource_lookup_dto.resource_type in tn_resource_types:
         book_content = tn_book_content(
-            resource_lookup_dto, resource_dir, resource_requests
+            resource_lookup_dto, resource_dir, resource_requests, layout_for_print
         )
     elif resource_lookup_dto.resource_type in tq_resource_types:
         book_content = tq_book_content(
-            resource_lookup_dto, resource_dir, resource_requests
+            resource_lookup_dto, resource_dir, resource_requests, layout_for_print
         )
     elif resource_lookup_dto.resource_type in tw_resource_types:
         book_content = tw_book_content(
-            resource_lookup_dto, resource_dir, resource_requests
+            resource_lookup_dto, resource_dir, resource_requests, layout_for_print
         )
     return book_content
+
+
+def is_footnote_ref(id: str) -> bool:
+    """
+    Predicate function used to find links that have an href value that
+    we expect footnote references to have.
+    """
+    return id is not None and re.compile("ref-fn-.*").match(id) is not None
 
 
 def usfm_book_content(
     resource_lookup_dto: model.ResourceLookupDto,
     resource_dir: str,
     resource_requests: Sequence[model.ResourceRequest],
+    layout_for_print: bool,
     h2: str = H2,
     bs_parser_type: str = "html.parser",
     css_attribute_type: str = "class",
@@ -228,10 +239,26 @@ def usfm_book_content(
     html_content = asset_content(resource_lookup_dto, resource_dir)
     parser = bs4.BeautifulSoup(html_content, bs_parser_type)
 
-    chapter_breaks = parser.find_all(h2, attrs={css_attribute_type: "c-num"})
-    localized_chapter_heading = chapter_breaks[0].get_text().split()[0]
+    if layout_for_print:
+        # Find all verse level footnote references for this chapter
+        verse_footnote_refs = parser.find_all(id=is_footnote_ref)
+        # Turn the found links into spans since we don't need
+        # links in a printed document.
+        for verse_footnote_ref in verse_footnote_refs:
+            verse_number = verse_footnote_ref.i.a.string
+            # Remove the link
+            span = parser.new_tag("span")
+            span.string = verse_number
+            verse_footnote_ref.i.a.replace_with(span)
+
+    chapter_break_tags = parser.find_all(h2, attrs={css_attribute_type: "c-num"})
+    # FIXME Accessing the localized_chapter_heading failed for a couple
+    # languages with an index out of range exception. Need to rerun full
+    # test suite to identify which ones and investigate why.
+    localized_chapter_heading_text = chapter_break_tags[0].get_text()
+    localized_chapter_heading = localized_chapter_heading_text.split()[0]
     chapters: dict[model.ChapterNum, model.USFMChapter] = {}
-    for chapter_break in chapter_breaks:
+    for chapter_break in chapter_break_tags:
         chapter_num = int(chapter_break.get_text().split()[1])
         chapter_content = html_parsing_utils.tag_elements_between(
             parser.find(
@@ -248,17 +275,33 @@ def usfm_book_content(
             "".join(chapter_content),
             bs_parser_type,
         )
+
         chapter_verse_span_tags = chapter_content_parser.find_all(
             "span", attrs={css_attribute_type: "v-num"}
         )
         chapter_footnote_tag = chapter_content_parser.find(
             "div", attrs={css_attribute_type: "footnotes"}
         )
+        if layout_for_print:
+            if chapter_footnote_tag:
+                chapter_footnote_str = str(chapter_footnote_tag)
+                chapter_footnotes_parser = bs4.BeautifulSoup(
+                    chapter_footnote_str, bs_parser_type
+                )
+                a_tags = chapter_footnotes_parser.find_all("a")
+                # Now we modify the footnote links to be inactive, i.e., not links so
+                # that they are suitable for printing.
+                for a_tag in a_tags:
+                    a_tag.name = "span"
+                # Now we just set the name to one we expect (for the next expression)
+                # which is executed for either case.
+                chapter_footnote_tag = chapter_footnotes_parser
         chapter_footnotes = (
             model.HtmlContent(str(chapter_footnote_tag))
             if chapter_footnote_tag
             else model.HtmlContent("")
         )
+
         # Dictionary to hold verse number, verse value pairs.
         chapter_verses: dict[str, str] = {}
         for verse_span_tag in chapter_verse_span_tags:
@@ -461,6 +504,7 @@ def tn_book_content(
     resource_lookup_dto: model.ResourceLookupDto,
     resource_dir: str,
     resource_requests: Sequence[model.ResourceRequest],
+    layout_for_print: bool,
     chapter_dirs_glob_fmt_str: str = "{}/**/*{}/*[0-9]*",
     chapter_dirs_glob_alt_fmt_str: str = "{}/*{}/*[0-9]*",
     intro_paths_glob_fmt_str: str = "{}/*intro.md",
@@ -476,6 +520,7 @@ def tn_book_content(
         resource_lookup_dto.lang_code,
         resource_lookup_dto.resource_type,
         resource_requests,
+        layout_for_print,
     )
     chapter_dirs = sorted(
         glob(
@@ -557,6 +602,7 @@ def tq_book_content(
     resource_lookup_dto: model.ResourceLookupDto,
     resource_dir: str,
     resource_requests: Sequence[model.ResourceRequest],
+    layout_for_print: bool,
     chapter_dirs_glob_fmt_str: str = "{}/**/*{}/*[0-9]*",
     chapter_dirs_glob_alt_fmt_str: str = "{}/*{}/*[0-9]*",
     verse_paths_glob_fmt_str: str = "{}/*[0-9]*.md",
@@ -567,6 +613,7 @@ def tq_book_content(
         resource_lookup_dto.lang_code,
         resource_lookup_dto.resource_type,
         resource_requests,
+        layout_for_print,
     )
     chapter_dirs = sorted(
         glob(
@@ -616,6 +663,7 @@ def tw_book_content(
     resource_lookup_dto: model.ResourceLookupDto,
     resource_dir: str,
     resource_requests: Sequence[model.ResourceRequest],
+    layout_for_print: bool,
     h1: str = H1,
     h2: str = H2,
     h3: str = H3,
@@ -627,6 +675,7 @@ def tw_book_content(
         resource_lookup_dto.lang_code,
         resource_lookup_dto.resource_type,
         resource_requests,
+        layout_for_print,
         resource_dir,
     )
     translation_word_filepaths = tw_utils.translation_word_filepaths(resource_dir)
@@ -673,6 +722,7 @@ def markdown_instance(
     lang_code: str,
     resource_type: str,
     resource_requests: Sequence[model.ResourceRequest],
+    layout_for_print: bool,
     tw_resource_dir: Optional[str] = None,
 ) -> markdown.Markdown:
     """
@@ -684,10 +734,29 @@ def markdown_instance(
     if not tw_resource_dir:
         tw_resource_dir = tw_utils.tw_resource_dir(lang_code)
     translation_words_dict = tw_utils.translation_words_dict(tw_resource_dir)
+    if not layout_for_print:  # User doesn't want to print result
+        return markdown.Markdown(
+            extensions=[
+                remove_section_preprocessor.RemoveSectionExtension(),
+                link_transformer_preprocessor.LinkTransformerExtension(
+                    lang_code=[lang_code, "Language code for resource"],
+                    resource_requests=[
+                        resource_requests,
+                        "The list of resource requests contained in the document request.",
+                    ],
+                    translation_words_dict=[
+                        translation_words_dict,
+                        "Dictionary mapping translation word asset file name sans suffix to translation word asset file path.",
+                    ],
+                ),
+            ]
+        )
+    # User set layout_for_print to True, so don't bother to link
+    # things since we are printing.
     return markdown.Markdown(
         extensions=[
             remove_section_preprocessor.RemoveSectionExtension(),
-            link_transformer_preprocessor.LinkTransformerExtension(
+            link_print_transformer_preprocessor.LinkPrintTransformerExtension(
                 lang_code=[lang_code, "Language code for resource"],
                 resource_requests=[
                     resource_requests,

--- a/backend/document/markdown_extensions/link_print_transformer_preprocessor.py
+++ b/backend/document/markdown_extensions/link_print_transformer_preprocessor.py
@@ -17,8 +17,12 @@ TW = "tw"
 
 
 @final
-class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
-    """Convert various link types to Markdown anchor links."""
+class LinkPrintTransformerPreprocessor(markdown.preprocessors.Preprocessor):
+    """
+    Convert various link types to text of the link description instead
+    of a live link since this is used for producing content suitable for
+    printing.
+    """
 
     def __init__(
         self,
@@ -114,11 +118,7 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
                 # Build the anchor link.
                 url = url.replace(
                     match.group(0),  # The whole match
-                    settings.TRANSLATION_WORD_ANCHOR_LINK_FMT_STR.format(
-                        localized_translation_word,
-                        self._lang_code,
-                        localized_translation_word,
-                    ),
+                    settings.TRANSLATION_WORD_FMT_STR.format(localized_translation_word),
                 )
             else:
                 url = url.replace(match.group(0), filename_sans_suffix)
@@ -160,9 +160,7 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
                 # Build the anchor links
                 source = source.replace(
                     match_text,
-                    settings.TRANSLATION_WORD_ANCHOR_LINK_FMT_STR.format(
-                        localized_translation_word,
-                        self._lang_code,
+                    settings.TRANSLATION_WORD_FMT_STR.format(
                         localized_translation_word,
                     ),
                 )
@@ -215,9 +213,7 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
                 # Build the anchor links
                 source = source.replace(
                     match.group(0),  # The whole match
-                    settings.TRANSLATION_WORD_ANCHOR_LINK_FMT_STR.format(
-                        localized_translation_word,
-                        self._lang_code,
+                    settings.TRANSLATION_WORD_FMT_STR.format(
                         localized_translation_word,
                     ),
                 )
@@ -269,10 +265,8 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
                 # Build the anchor links
                 source = source.replace(
                     match.group(0),  # The whole match
-                    settings.TRANSLATION_WORD_PREFIX_ANCHOR_LINK_FMT_STR.format(
+                    settings.TRANSLATION_WORD_PREFIX_FMT_STR.format(
                         match.group("prefix_text"),
-                        localized_translation_word,
-                        self._lang_code,
                         localized_translation_word,
                     ),
                 )
@@ -370,59 +364,59 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
             chapter_num = match.group("chapter_num")
             verse_ref = match.group("verse_ref")
 
-            # NOTE(id:check_for_resource_request) To bother getting the TN resource
-            # asset file referenced in the matched link we must know that said TN
-            # resource identified by the lang_code/resource_type/resource_code combo
-            # in the link has been requested by the user in the DocumentRequest.
-            tn_resource_requests: list[model.ResourceRequest] = [
-                resource_request
-                for resource_request in self._resource_requests
-                if resource_request.lang_code == lang_code
-                and TN in resource_request.resource_type
-                and resource_request.resource_code == resource_code
-            ]
-            if tn_resource_requests:
-                tn_resource_request: model.ResourceRequest = tn_resource_requests[0]
-                # Build a file path to the TN note being requested.
-                first_resource_path_segment = "{}_{}".format(
-                    tn_resource_request.lang_code,
-                    tn_resource_request.resource_type,
-                )
-                second_resource_path_segment = "{}_tn".format(
-                    tn_resource_request.lang_code
-                )
-                path = "{}.md".format(
-                    os.path.join(
-                        working_dir,
-                        first_resource_path_segment,
-                        second_resource_path_segment,
-                        resource_code,
-                        chapter_num,
-                        verse_ref,
-                    )
-                )
-                if os.path.exists(path):  # file path to TN note exists
-                    # Create anchor link to translation note
-                    new_link = settings.TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR.format(
-                        scripture_ref,
-                        tn_resource_request.lang_code,
-                        bible_books.BOOK_NUMBERS[
-                            tn_resource_request.resource_code
-                        ].zfill(3),
-                        chapter_num.zfill(3),
-                        verse_ref.zfill(3),
-                    )
-                    # Replace the match text with the new anchor link
-                    source = source.replace(
-                        match.group(0),  # The whole match
-                        "({})".format(new_link),
-                    )
-                else:  # TN note file does not exist.
-                    # Replace link with link text only.
-                    source = source.replace(match.group(0), scripture_ref)
-            else:  # TN resource that link requested was not included as part of the DocumentRequest
-                # Replace link with link text only.
-                source = source.replace(match.group(0), scripture_ref)
+            # # NOTE(id:check_for_resource_request) To bother getting the TN resource
+            # # asset file referenced in the matched link we must know that said TN
+            # # resource identified by the lang_code/resource_type/resource_code combo
+            # # in the link has been requested by the user in the DocumentRequest.
+            # tn_resource_requests: list[model.ResourceRequest] = [
+            #     resource_request
+            #     for resource_request in self._resource_requests
+            #     if resource_request.lang_code == lang_code
+            #     and TN in resource_request.resource_type
+            #     and resource_request.resource_code == resource_code
+            # ]
+            # if tn_resource_requests:
+            #     tn_resource_request: model.ResourceRequest = tn_resource_requests[0]
+            #     # Build a file path to the TN note being requested.
+            #     first_resource_path_segment = "{}_{}".format(
+            #         tn_resource_request.lang_code,
+            #         tn_resource_request.resource_type,
+            #     )
+            #     second_resource_path_segment = "{}_tn".format(
+            #         tn_resource_request.lang_code
+            #     )
+            #     path = "{}.md".format(
+            #         os.path.join(
+            #             working_dir,
+            #             first_resource_path_segment,
+            #             second_resource_path_segment,
+            #             resource_code,
+            #             chapter_num,
+            #             verse_ref,
+            #         )
+            #     )
+            #     if os.path.exists(path):  # file path to TN note exists
+            #         # Create anchor link to translation note
+            #         new_link = settings.TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR.format(
+            #             scripture_ref,
+            #             tn_resource_request.lang_code,
+            #             bible_books.BOOK_NUMBERS[
+            #                 tn_resource_request.resource_code
+            #             ].zfill(3),
+            #             chapter_num.zfill(3),
+            #             verse_ref.zfill(3),
+            #         )
+            #         # Replace the match text with the new anchor link
+            #         source = source.replace(
+            #             match.group(0),  # The whole match
+            #             "({})".format(new_link),
+            #         )
+            #     else:  # TN note file does not exist.
+            #         # Replace link with link text only.
+            #         source = source.replace(match.group(0), scripture_ref)
+            # else:  # TN resource that link requested was not included as part of the DocumentRequest
+            # Replace link with link text only.
+            source = source.replace(match.group(0), scripture_ref)
 
         return source
 
@@ -441,61 +435,61 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
             verse_ref = match.group("verse_ref")
 
             # NOTE See id:check_for_resource_request above
-            matching_resource_requests: list[model.ResourceRequest] = [
-                resource_request
-                for resource_request in self._resource_requests
-                if resource_request.lang_code == self._lang_code
-                and TN in resource_request.resource_type
-                and resource_request.resource_code == resource_code
-            ]
-            if matching_resource_requests:
-                matching_resource_request: model.ResourceRequest = (
-                    matching_resource_requests[0]
-                )
-                # Build a file path to the TN note being requested.
-                first_resource_path_segment = "{}_{}".format(
-                    matching_resource_request.lang_code,
-                    matching_resource_request.resource_type,
-                )
-                second_resource_path_segment = "{}_tn".format(
-                    matching_resource_request.lang_code
-                )
-                path = "{}.md".format(
-                    os.path.join(
-                        settings.working_dir(),
-                        first_resource_path_segment,
-                        second_resource_path_segment,
-                        resource_code,
-                        chapter_num,
-                        verse_ref,
-                    )
-                )
-                if os.path.exists(path):  # file path to TN note exists
-                    # Create anchor link to translation note
-                    new_link = settings.TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR.format(
-                        scripture_ref,
-                        self._lang_code,
-                        bible_books.BOOK_NUMBERS[resource_code].zfill(3),
-                        chapter_num.zfill(3),
-                        verse_ref.zfill(3),
-                    )
-                    # Replace the match text with the new anchor link
-                    source = source.replace(
-                        match.group(0),  # The whole match
-                        "({})".format(new_link),
-                    )
-                else:  # TN note file does not exist.
-                    # Replace match text from the source text with the
-                    # link text only so that is not clickable.
-                    # The whole match plus surrounding parenthesis
-                    source = source.replace(
-                        "({})".format(match.group(0)), scripture_ref
-                    )
-            else:  # TN resource that link requested was not included as part of the
-                # DocumentRequest Replace match text from the source text with the link
-                # text only so that is not clickable.
-                # The whole match plus surrounding parenthesis
-                source = source.replace("({})".format(match.group(0)), scripture_ref)
+            # matching_resource_requests: list[model.ResourceRequest] = [
+            #     resource_request
+            #     for resource_request in self._resource_requests
+            #     if resource_request.lang_code == self._lang_code
+            #     and TN in resource_request.resource_type
+            #     and resource_request.resource_code == resource_code
+            # ]
+            # if matching_resource_requests:
+            #     matching_resource_request: model.ResourceRequest = (
+            #         matching_resource_requests[0]
+            #     )
+            #     # Build a file path to the TN note being requested.
+            #     first_resource_path_segment = "{}_{}".format(
+            #         matching_resource_request.lang_code,
+            #         matching_resource_request.resource_type,
+            #     )
+            #     second_resource_path_segment = "{}_tn".format(
+            #         matching_resource_request.lang_code
+            #     )
+            #     path = "{}.md".format(
+            #         os.path.join(
+            #             settings.working_dir(),
+            #             first_resource_path_segment,
+            #             second_resource_path_segment,
+            #             resource_code,
+            #             chapter_num,
+            #             verse_ref,
+            #         )
+            #     )
+            #     if os.path.exists(path):  # file path to TN note exists
+            #         # Create anchor link to translation note
+            #         new_link = settings.TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR.format(
+            #             scripture_ref,
+            #             self._lang_code,
+            #             bible_books.BOOK_NUMBERS[resource_code].zfill(3),
+            #             chapter_num.zfill(3),
+            #             verse_ref.zfill(3),
+            #         )
+            #         # Replace the match text with the new anchor link
+            #         source = source.replace(
+            #             match.group(0),  # The whole match
+            #             "({})".format(new_link),
+            #         )
+            #     else:  # TN note file does not exist.
+            #         # Replace match text from the source text with the
+            #         # link text only so that is not clickable.
+            #         # The whole match plus surrounding parenthesis
+            #         source = source.replace(
+            #             "({})".format(match.group(0)), scripture_ref
+            #         )
+            # else:  # TN resource that link requested was not included as part of the
+            # DocumentRequest Replace match text from the source text with the link
+            # text only so that is not clickable.
+            # The whole match plus surrounding parenthesis
+            source = source.replace("({})".format(match.group(0)), scripture_ref)
 
         return source
 
@@ -512,62 +506,62 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
             chapter_num = match.group("chapter_num")
             verse_ref = match.group("verse_ref")
 
-            matching_resource_requests: list[model.ResourceRequest] = [
-                resource_request
-                for resource_request in self._resource_requests
-                if resource_request.lang_code == self._lang_code
-                and TN in resource_request.resource_type
-            ]
-            resource_code = ""
-            if matching_resource_requests:
-                matching_resource_request: model.ResourceRequest = (
-                    matching_resource_requests[0]
-                )
-                resource_code = matching_resource_request.resource_code
-                # Build a file path to the TN note being requested.
-                first_resource_path_segment = "{}_{}".format(
-                    matching_resource_request.lang_code,
-                    matching_resource_request.resource_type,
-                )
-                second_resource_path_segment = "{}_tn".format(
-                    matching_resource_request.lang_code
-                )
-                path = "{}.md".format(
-                    os.path.join(
-                        settings.working_dir(),
-                        first_resource_path_segment,
-                        second_resource_path_segment,
-                        resource_code,
-                        chapter_num,
-                        verse_ref,
-                    )
-                )
-                if os.path.exists(path):  # file path to TN note exists
-                    # Create anchor link to translation note
-                    new_link = settings.TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR.format(
-                        scripture_ref,
-                        self._lang_code,
-                        bible_books.BOOK_NUMBERS[resource_code].zfill(3),
-                        chapter_num.zfill(3),
-                        verse_ref.zfill(3),
-                    )
-                    # Replace the match text with the new anchor link
-                    source = source.replace(
-                        match.group(0),  # The whole match
-                        "({})".format(new_link),
-                    )
-                else:  # TN note file does not exist.
-                    # Replace match text from the source text with the
-                    # link text only so that is not clickable.
-                    # The whole match plus surrounding parenthesis
-                    source = source.replace(
-                        "({})".format(match.group(0)), scripture_ref
-                    )
-            else:  # TN resource that link requested was not included as part of the
-                # DocumentRequest Replace match text from the source text with the link
-                # text only so that is not clickable.
-                # The whole match plus surrounding parenthesis
-                source = source.replace("({})".format(match.group(0)), scripture_ref)
+            # matching_resource_requests: list[model.ResourceRequest] = [
+            #     resource_request
+            #     for resource_request in self._resource_requests
+            #     if resource_request.lang_code == self._lang_code
+            #     and TN in resource_request.resource_type
+            # ]
+            # resource_code = ""
+            # if matching_resource_requests:
+            #     matching_resource_request: model.ResourceRequest = (
+            #         matching_resource_requests[0]
+            #     )
+            #     resource_code = matching_resource_request.resource_code
+            #     # Build a file path to the TN note being requested.
+            #     first_resource_path_segment = "{}_{}".format(
+            #         matching_resource_request.lang_code,
+            #         matching_resource_request.resource_type,
+            #     )
+            #     second_resource_path_segment = "{}_tn".format(
+            #         matching_resource_request.lang_code
+            #     )
+            #     path = "{}.md".format(
+            #         os.path.join(
+            #             settings.working_dir(),
+            #             first_resource_path_segment,
+            #             second_resource_path_segment,
+            #             resource_code,
+            #             chapter_num,
+            #             verse_ref,
+            #         )
+            #     )
+            #     if os.path.exists(path):  # file path to TN note exists
+            #         # Create anchor link to translation note
+            #         new_link = settings.TRANSLATION_NOTE_ANCHOR_LINK_FMT_STR.format(
+            #             scripture_ref,
+            #             self._lang_code,
+            #             bible_books.BOOK_NUMBERS[resource_code].zfill(3),
+            #             chapter_num.zfill(3),
+            #             verse_ref.zfill(3),
+            #         )
+            #         # Replace the match text with the new anchor link
+            #         source = source.replace(
+            #             match.group(0),  # The whole match
+            #             "({})".format(new_link),
+            #         )
+            #     else:  # TN note file does not exist.
+            #         # Replace match text from the source text with the
+            #         # link text only so that is not clickable.
+            #         # The whole match plus surrounding parenthesis
+            #         source = source.replace(
+            #             "({})".format(match.group(0)), scripture_ref
+            #         )
+            # else:  # TN resource that link requested was not included as part of the
+            # DocumentRequest Replace match text from the source text with the link
+            # text only so that is not clickable.
+            # The whole match plus surrounding parenthesis
+            source = source.replace("({})".format(match.group(0)), scripture_ref)
 
         return source
 
@@ -584,7 +578,7 @@ class LinkTransformerPreprocessor(markdown.preprocessors.Preprocessor):
         return source
 
 
-class LinkTransformerExtension(markdown.Extension):
+class LinkPrintTransformerExtension(markdown.Extension):
     """A Markdown link conversion extension."""
 
     def __init__(self, *args: str, **kwargs: Any) -> None:
@@ -595,15 +589,15 @@ class LinkTransformerExtension(markdown.Extension):
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:
         """Automatically called by superclass."""
-        link_transformer = LinkTransformerPreprocessor(
+        link_print_transformer = LinkPrintTransformerPreprocessor(
             md,
             self.getConfig("lang_code"),
             self.getConfig("resource_requests"),
             self.getConfig("translation_words_dict"),
         )
         md.preprocessors.register(
-            link_transformer,
-            "link_transformer",
+            link_print_transformer,
+            "link_print_transformer",
             32,
         )
 

--- a/backend/document/markdown_extensions/link_print_transformer_preprocessor.py
+++ b/backend/document/markdown_extensions/link_print_transformer_preprocessor.py
@@ -73,6 +73,7 @@ class LinkPrintTransformerPreprocessor(markdown.preprocessors.Preprocessor):
         # by self.transform_tn_markdown_links.
         source = self.transform_tn_missing_resource_code_markdown_links(source)
         source = self.transform_tn_obs_markdown_links(source)
+        source = self.transform_bc_markdown_links(source)
         return source.split("\n")
 
     def transform_tw_rc_link(self, wikilink: model.WikiLink, source: str) -> str:
@@ -118,7 +119,9 @@ class LinkPrintTransformerPreprocessor(markdown.preprocessors.Preprocessor):
                 # Build the anchor link.
                 url = url.replace(
                     match.group(0),  # The whole match
-                    settings.TRANSLATION_WORD_FMT_STR.format(localized_translation_word),
+                    settings.TRANSLATION_WORD_FMT_STR.format(
+                        localized_translation_word
+                    ),
                 )
             else:
                 url = url.replace(match.group(0), filename_sans_suffix)
@@ -574,6 +577,19 @@ class LinkPrintTransformerPreprocessor(markdown.preprocessors.Preprocessor):
             # Build the anchor links
             # FIXME Actually create a meaningful link rather than just
             # link text
+            source = source.replace(match.group(0), match.group("link_text"))
+        return source
+
+    def transform_bc_markdown_links(
+        self,
+        source: str,
+    ) -> str:
+        """
+        Replace bible commentary relative link with link text.
+        """
+        for match in re.finditer(link_regexes.BC_MARKDOWN_LINK_RE, source):
+            # Build the anchor links to referenced bible commentary
+            # articles.
             source = source.replace(match.group(0), match.group("link_text"))
         return source
 

--- a/backend/document/markdown_extensions/link_regexes.py
+++ b/backend/document/markdown_extensions/link_regexes.py
@@ -150,3 +150,10 @@ TN_OBS_MARKDOWN_LINK_RE = re.compile(
 )
 
 # TN_VERSE_ID_REGEX = r"id=\"(?P<lang_code>.*?)-(?P<book_num>.*?)-tn-ch-(?P<chapter_num>.*?)-v-(?P<verse_ref>.*?)\""
+
+
+# See: [Covenant with David](../articles/covenantdavid.md); [Messiah (Christ)](../articles/messiahchrist.md); [Ancestor and Descendant (Fathers, Forefathers, Patriarchs)](../articles/ancestor.md); [Son of David](../articles/sonofdavid.md)
+# More particularly:  [Covenant with David](../articles/covenantdavid.md)
+BC_MARKDOWN_LINK_RE = re.compile(
+    r"\[(?P<link_text>.+?)\] *\(\.\.\/(?P<link_ref>articles.+?)\)"
+)

--- a/backend/requirements-prod.txt
+++ b/backend/requirements-prod.txt
@@ -4,19 +4,17 @@
 #
 #    pip-compile ./backend/requirements-prod.in
 #
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
-backports-entry-points-selectable==1.1.1
-    # via virtualenv
 cfgv==3.3.1
     # via pre-commit
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.6.0
     # via virtualenv
 icdiff==2.0.4
     # via pytest-icdiff
-identify==2.4.0
+identify==2.4.12
     # via pre-commit
 iniconfig==1.1.1
     # via pytest
@@ -28,13 +26,13 @@ nodeenv==1.6.0
     # via pre-commit
 packaging==21.3
     # via pytest
-platformdirs==2.4.0
+platformdirs==2.5.1
     # via virtualenv
 pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-pre-commit==2.16.0
+pre-commit==2.17.0
     # via -r ./backend/requirements-prod.in
 py==1.11.0
     # via
@@ -44,7 +42,7 @@ pyparsing==2.4.5
     # via
     #   -c ./backend/requirements.txt
     #   packaging
-pytest==6.2.5
+pytest==7.1.1
     # via
     #   -r ./backend/requirements-prod.in
     #   pytest-datafiles
@@ -62,14 +60,14 @@ six==1.16.0
     #   -c ./backend/requirements.txt
     #   virtualenv
 toml==0.10.2
+    # via pre-commit
+tomli==2.0.1
     # via
-    #   pre-commit
+    #   mypy
     #   pytest
-tomli==2.0.0
-    # via mypy
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   -c ./backend/requirements.txt
     #   mypy
-virtualenv==20.10.0
+virtualenv==20.13.4
     # via pre-commit

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,9 +6,9 @@
 #
 aiofiles==0.8.0
     # via -r ./backend/requirements.in
-anyio==3.4.0
+anyio==3.5.0
     # via starlette
-asgiref==3.4.1
+asgiref==3.5.0
     # via uvicorn
 beautifulsoup4==4.10.0
     # via bs4
@@ -16,23 +16,23 @@ bs4==0.0.1
     # via -r ./backend/requirements.in
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.12
     # via requests
-click==8.0.3
+click==8.0.4
     # via uvicorn
-decorator==5.1.0
+decorator==5.1.1
     # via jsonpath-rw
-dnspython==2.1.0
+dnspython==2.2.1
     # via email-validator
 email-validator==1.1.3
     # via pydantic
-fastapi==0.70.1
+fastapi==0.75.0
     # via -r ./backend/requirements.in
 future==0.18.2
     # via usfm-tools
 gunicorn==20.1.0
     # via -r ./backend/requirements.in
-h11==0.12.0
+h11==0.13.0
     # via uvicorn
 idna==3.3
     # via
@@ -49,17 +49,17 @@ jsonpath-rw-ext==1.2.2
     # via -r ./backend/requirements.in
 markdown==3.3.6
     # via -r ./backend/requirements.in
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 more-itertools==8.12.0
     # via -r ./backend/requirements.in
-pbr==5.8.0
+pbr==5.8.1
     # via jsonpath-rw-ext
 pdfkit==1.0.0
     # via -r ./backend/requirements.in
 ply==3.11
     # via jsonpath-rw
-pydantic[dotenv,email]==1.8.2
+pydantic[dotenv,email]==1.9.0
     # via
     #   -r ./backend/requirements.in
     #   fastapi
@@ -71,7 +71,7 @@ python-dotenv==0.19.2
     # via pydantic
 pyyaml==6.0
     # via -r ./backend/requirements.in
-requests==2.26.0
+requests==2.27.1
     # via -r ./backend/requirements.in
 six==1.16.0
     # via jsonpath-rw
@@ -79,35 +79,37 @@ sniffio==1.2.0
     # via anyio
 soupsieve==2.3.1
     # via beautifulsoup4
-starlette==0.16.0
+starlette==0.17.1
     # via fastapi
 termcolor==1.1.0
     # via -r ./backend/requirements.in
-types-beautifulsoup4==4.10.6
+types-beautifulsoup4==4.10.16
     # via -r ./backend/requirements.in
-types-markdown==3.3.9
+types-markdown==3.3.12
     # via -r ./backend/requirements.in
-types-orjson==3.6.1
+types-orjson==3.6.2
     # via -r ./backend/requirements.in
-types-pyyaml==6.0.1
+types-pyyaml==6.0.5
     # via -r ./backend/requirements.in
-types-requests==2.26.2
+types-requests==2.27.14
     # via -r ./backend/requirements.in
-types-setuptools==57.4.4
+types-setuptools==57.4.11
     # via -r ./backend/requirements.in
-types-termcolor==1.1.2
+types-termcolor==1.1.3
     # via -r ./backend/requirements.in
-types-toml==0.10.1
+types-toml==0.10.4
     # via -r ./backend/requirements.in
-types-ujson==4.2.0
+types-ujson==4.2.1
     # via -r ./backend/requirements.in
-typing-extensions==4.0.1
+types-urllib3==1.26.11
+    # via types-requests
+typing-extensions==4.1.1
     # via pydantic
-urllib3==1.26.7
+urllib3==1.26.9
     # via requests
 usfm-tools @ git+https://github.com/linearcombination/USFM-Tools.git@develop
     # via -r ./backend/requirements.in
-uvicorn==0.16.0
+uvicorn==0.17.6
     # via -r ./backend/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/backend/templates/html/header_compact_enclosing.html
+++ b/backend/templates/html/header_compact_enclosing.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Bible</title>
+    <!-- <link
+         rel="stylesheet"
+         href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+         /> -->
+    <style media="all" type="text/css">
+      h1 {
+        font-size: 14pt;
+        margin-bottom: 0px;
+        padding-bottom: 0px;
+        display: inline;
+      }
+      h1:after {
+          content: "\A";
+          white-space: pre;
+      }
+      h2 {
+        font-size: 12pt;
+        display: inline;
+      }
+      h2:after {
+          content: "\A";
+          white-space: pre;
+      }
+      h3 {
+        font-size: 11pt;
+        display: inline;
+      }
+      h3:after {
+          content: "\A";
+          white-space: pre;
+      }
+      h4 {
+        font-size: 10pt;
+        display: inline;
+      }
+      h4:after {
+          content: "\A";
+          white-space: pre;
+      }
+      h5:after {
+          content: "\A";
+          white-space: pre;
+      }
+      h5 {
+        font-size: 9pt;
+        display: inline;
+      }
+      p {
+        display: inline;
+      }
+      p:after {
+        content: "\A";
+        white-space: pre;
+      }
+      ol {
+        display: inline;
+      }
+      ol:after {
+          content: "\A";
+          white-space: pre;
+      }
+      ul {
+        display: inline;
+      }
+      ul:after {
+          content: "\A";
+          white-space: pre;
+      }
+      li {
+        display: inline;
+      }
+      .indent-0 {
+          margin-left: 0em;
+          margin-bottom: 0em;
+          margin-top: 0em;
+      }
+      .indent-1 {
+          margin-left: 0em;
+          margin-bottom: 0em;
+          margin-top: 0em;
+      }
+      .indent-2 {
+          margin-left: 1em;
+          margin-bottom: 0em;
+          margin-top: 0em;
+      }
+      .indent-3 {
+          margin-left: 2em;
+          margin-bottom: 0em;
+          margin-top: 0em;
+      }
+      .c-num {
+          color: gray;
+      }
+      .v-num {
+          color: gray;
+      }
+      <!-- .tetragrammaton { -->
+      <!--   font-variant: small-caps; -->
+      <!-- } -->
+      .footnotes {
+          font-size: 0.8em;
+      }
+      .footnotes-hr {
+          display: none;
+      }
+      .column {
+          float: left;
+          width: 50%;
+      }
+      .row:after {
+          content: "";
+          display: table;
+          clear: both;
+      }
+    </style>
+  </head>
+  <body>

--- a/backend/templates/html/header_enclosing.html
+++ b/backend/templates/html/header_enclosing.html
@@ -8,26 +8,26 @@
          href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
          /> -->
     <style media="all" type="text/css">
-      <!-- .indent-0 { -->
-      <!--   margin-left: 0em; -->
-      <!--   margin-bottom: 0em; -->
-      <!--   margin-top: 0em; -->
-      <!-- } -->
-      <!-- .indent-1 { -->
-      <!--   margin-left: 0em; -->
-      <!--   margin-bottom: 0em; -->
-      <!--   margin-top: 0em; -->
-      <!-- } -->
-      <!-- .indent-2 { -->
-      <!--   margin-left: 1em; -->
-      <!--   margin-bottom: 0em; -->
-      <!--   margin-top: 0em; -->
-      <!-- } -->
-      <!-- .indent-3 { -->
-      <!--   margin-left: 2em; -->
-      <!--   margin-bottom: 0em; -->
-      <!--   margin-top: 0em; -->
-      <!-- } -->
+      .indent-0 {
+        margin-left: 0em;
+        margin-bottom: 0em;
+        margin-top: 0em;
+      }
+      .indent-1 {
+        margin-left: 0em;
+        margin-bottom: 0em;
+        margin-top: 0em;
+      }
+      .indent-2 {
+        margin-left: 1em;
+        margin-bottom: 0em;
+        margin-top: 0em;
+      }
+      .indent-3 {
+        margin-left: 2em;
+        margin-bottom: 0em;
+        margin-top: 0em;
+      }
       .c-num {
         color: gray;
       }

--- a/frontend/.env
+++ b/frontend/.env
@@ -2,8 +2,10 @@
 VITE_BACKEND_API_URL="http://localhost:5005"
 # VITE_BACKEND_API_URL="http://dev.local:5005"
 
-VITE_BOOK_LANGUAGE_ORDER_LABEL="Sort by book then by language"
-VITE_LANGUAGE_BOOK_ORDER_LABEL="Sort by language then by book"
+# VITE_BOOK_LANGUAGE_ORDER_LABEL="Sort by book then by language"
+VITE_BOOK_LANGUAGE_ORDER_LABEL="Mix content for each language verse by verse"
+# VITE_LANGUAGE_BOOK_ORDER_LABEL="Sort by language then by book"
+VITE_LANGUAGE_BOOK_ORDER_LABEL="Keep content for each language separately grouped"
 
 VITE_WAIT_MSG="Thank you for submitting your document request. Please wait while the system generates your document. Note that, depending on the size of the document, and especially if this is the first time this document has been requested, this could take a while. A link will be presented to you in place of this message if the document is generated successfully. If you have provided an email address above, the same link will also be sent to the email address provided. Thank you for your patience."
 
@@ -11,7 +13,9 @@ VITE_ERROR_MSG="There was a problem handling your document request. The issue ha
 
 VITE_TOP_H2_HEADER="Document Request"
 VITE_EMAIL_LABEL="Email (Optional)"
-VITE_ASSEMBLY_STRATEGY_HEADER="Please select the assembly strategy for this document"
+VITE_LAYOUT_FOR_PRINT_LABEL="Do you want to format the result for printing (less whitespace)?"
+# VITE_ASSEMBLY_STRATEGY_HEADER="Please select the assembly strategy for this document"
+VITE_ASSEMBLY_STRATEGY_HEADER="How do you want to group content?"
 
 VITE_ADD_ANOTHER_LANGUAGE_BUTTON_TXT="Add another language"
 
@@ -27,6 +31,10 @@ VITE_LANG_2_HEADER="Language #3"
 VITE_LANG_2_RESOURCE_TYPES_HEADER="Language #3 resource types"
 VITE_LANG_2_RESOURCE_CODES_HEADER="Language #3 resource codes"
 
-VITE_DOCUMENT_READY_MSG_PART1="Your document is ready, please click"
-VITE_DOCUMENT_READY_LINK_TXT="here"
-VITE_DOCUMENT_READY_MSG_PART2="to retrieve it."
+VITE_PDF_DOCUMENT_READY_MSG_PART1="Your PDF document is ready, please click"
+VITE_PDF_DOCUMENT_READY_LINK_TXT="here"
+VITE_PDF_DOCUMENT_READY_MSG_PART2="to retrieve it."
+
+VITE_HTML_DOCUMENT_READY_MSG_PART1="Your HTML document is ready, please click"
+VITE_HTML_DOCUMENT_READY_LINK_TXT="here"
+VITE_HTML_DOCUMENT_READY_MSG_PART2="to retrieve it."

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 0, "development-stage", based on Node.js, to build the
 # frontend and run it in 'development' mode.
-FROM node:17.5.0-bullseye-slim as development-stage
+FROM node:17.7.1-bullseye-slim as development-stage
 
 RUN apt-get update && apt-get install -y \
     python3  \

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,90 @@
         "vite": "^2.7.2"
       }
     },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
@@ -37,28 +121,10 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.37",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.37.tgz",
-      "integrity": "sha512-EdSXw2rXeOahNrQfMJVZxa/NxZxW1a0TiBI3s+pVxnxU14hEQtnkLtdbTFhnceu22gJpNPFSIJRcIwRBBDQIeA==",
+      "version": "1.0.0-next.39",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.39.tgz",
+      "integrity": "sha512-gnvvcAW2LK+KnUn8lKb2ypcXKwSp2K57mem5C4VNKfjxdRpM6+XwNavWwVf6otnDhz3qPYl/TKKW6/dRr6eeAw==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
@@ -87,18 +153,42 @@
       "integrity": "sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A==",
       "dev": true
     },
-    "node_modules/@types/node": {
+    "node_modules/@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-      "integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
+    "node_modules/@types/node": {
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
+    },
+    "node_modules/@types/pug": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
+      "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
+      "dev": true
+    },
+    "node_modules/@types/sass": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/type-utils": "5.12.1",
-        "@typescript-eslint/utils": "5.12.1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
+      "integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/type-utils": "5.13.0",
+        "@typescript-eslint/utils": "5.13.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -124,14 +214,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-      "integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
+      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -150,169 +240,14 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-      "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-      "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-      "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-      "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
+      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1"
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -320,54 +255,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-      "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-      "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-      "integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
+      "integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.12.1",
+        "@typescript-eslint/utils": "5.13.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -387,40 +283,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-      "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-      "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
+      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -430,14 +296,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-      "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
+      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -457,13 +323,37 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-      "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
+      "integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
+      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.13.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -474,7 +364,87 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/array-union": {
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
@@ -483,163 +453,75 @@
         "node": ">=8"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "dependencies": {
-        "path-type": "^4.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -669,66 +551,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar/node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/chokidar/node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -741,91 +563,42 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chokidar/node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "binary-extensions": "^2.0.0"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/chokidar/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
-    "node_modules/chokidar/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "dependencies": {
-        "is-extglob": "^2.1.1"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chokidar/node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/chokidar/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chokidar/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/chokidar/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/chokidar/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -845,11 +618,260 @@
         }
       }
     },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.23.tgz",
+      "integrity": "sha512-XjnIcZ9KB6lfonCa+jRguXyRYcldmkyZ99ieDksqW/C8bnyEX299yA4QH2XcgijCgaddEZePPTgvx/2imsq7Ig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.14.23",
+        "esbuild-darwin-64": "0.14.23",
+        "esbuild-darwin-arm64": "0.14.23",
+        "esbuild-freebsd-64": "0.14.23",
+        "esbuild-freebsd-arm64": "0.14.23",
+        "esbuild-linux-32": "0.14.23",
+        "esbuild-linux-64": "0.14.23",
+        "esbuild-linux-arm": "0.14.23",
+        "esbuild-linux-arm64": "0.14.23",
+        "esbuild-linux-mips64le": "0.14.23",
+        "esbuild-linux-ppc64le": "0.14.23",
+        "esbuild-linux-riscv64": "0.14.23",
+        "esbuild-linux-s390x": "0.14.23",
+        "esbuild-netbsd-64": "0.14.23",
+        "esbuild-openbsd-64": "0.14.23",
+        "esbuild-sunos-64": "0.14.23",
+        "esbuild-windows-32": "0.14.23",
+        "esbuild-windows-64": "0.14.23",
+        "esbuild-windows-arm64": "0.14.23"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.23.tgz",
+      "integrity": "sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.23.tgz",
+      "integrity": "sha512-lB0XRbtOYYL1tLcYw8BoBaYsFYiR48RPrA0KfA/7RFTr4MV7Bwy/J4+7nLsVnv9FGuQummM3uJ93J3ptaTqFug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.23.tgz",
+      "integrity": "sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.23.tgz",
+      "integrity": "sha512-/1xiTjoLuQ+LlbfjJdKkX45qK/M7ARrbLmyf7x3JhyQGMjcxRYVR6Dw81uH3qlMHwT4cfLW4aEVBhP1aNV7VsA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.23.tgz",
+      "integrity": "sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.23.tgz",
+      "integrity": "sha512-37R/WMkQyUfNhbH7aJrr1uCjDVdnPeTHGeDhZPUNhfoHV0lQuZNCKuNnDvlH/u/nwIYZNdVvz1Igv5rY/zfrzQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.23.tgz",
+      "integrity": "sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.23.tgz",
+      "integrity": "sha512-x64CEUxi8+EzOAIpCUeuni0bZfzPw/65r8tC5cy5zOq9dY7ysOi5EVQHnzaxS+1NmV+/RVRpmrzGw1QgY2Xpmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.23.tgz",
+      "integrity": "sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.23.tgz",
+      "integrity": "sha512-kHKyKRIAedYhKug2EJpyJxOUj3VYuamOVA1pY7EimoFPzaF3NeY7e4cFBAISC/Av0/tiV0xlFCt9q0HJ68IBIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.23.tgz",
+      "integrity": "sha512-7ilAiJEPuJJnJp/LiDO0oJm5ygbBPzhchJJh9HsHZzeqO+3PUzItXi+8PuicY08r0AaaOe25LA7sGJ0MzbfBag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-riscv64": {
       "version": "0.14.23",
@@ -883,13 +905,121 @@
         "node": ">=12"
       }
     },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
+      "integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
+      "integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
+      "integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
+      "integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
+      "integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
+      "integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -948,236 +1078,20 @@
         "svelte": "^3.2.0"
       }
     },
-    "node_modules/eslint/node_modules/@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "dev": true,
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/eslint/node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/eslint/node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "estraverse": "^4.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=8.0.0"
       }
     },
-    "node_modules/eslint/node_modules/eslint-utils": {
+    "node_modules/eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
@@ -1195,7 +1109,7 @@
         "eslint": ">=5"
       }
     },
-    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
@@ -1204,7 +1118,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-visitor-keys": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
@@ -1213,7 +1127,29 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/espree": {
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/espree": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
@@ -1227,7 +1163,7 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/esquery": {
+    "node_modules/esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
@@ -1239,7 +1175,16 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/eslint/node_modules/esrecurse": {
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
@@ -1251,7 +1196,7 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/eslint/node_modules/estraverse": {
+    "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
@@ -1260,7 +1205,22 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/eslint/node_modules/esutils": {
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
@@ -1269,25 +1229,62 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint/node_modules/fast-deep-equal": {
+    "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "node_modules/eslint/node_modules/fast-json-stable-stringify": {
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
-    "node_modules/eslint/node_modules/fast-levenshtein": {
+    "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "node_modules/eslint/node_modules/file-entry-cache": {
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
@@ -1299,7 +1296,19 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/eslint/node_modules/flat-cache": {
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
@@ -1312,19 +1321,45 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/eslint/node_modules/flatted": {
+    "node_modules/flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "node_modules/eslint/node_modules/fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/eslint/node_modules/glob": {
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
@@ -1344,7 +1379,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eslint/node_modules/glob-parent": {
+    "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
@@ -1356,7 +1391,7 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/eslint/node_modules/globals": {
+    "node_modules/globals": {
       "version": "13.12.1",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
       "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
@@ -1371,285 +1406,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/eslint/node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/eslint/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/eslint/node_modules/natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/eslint/node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/eslint/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1657,281 +1426,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/eslint/node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+    "node_modules/graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
-    "node_modules/eslint/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
+        "function-bind": "^1.1.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 0.4.0"
       }
     },
-    "node_modules/eslint/node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint/node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/fast-glob/node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "dev": true,
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fast-glob/node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/fast-glob/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/fast-glob/node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/fast-glob/node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/fast-glob/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -1958,35 +1478,114 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-fresh/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=0.8.19"
       }
     },
-    "node_modules/import-fresh/node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "node_modules/kleur": {
       "version": "4.1.4",
@@ -1997,25 +1596,120 @@
         "node": ">=6"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "node_modules/magic-string/node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.8.tgz",
+      "integrity": "sha512-n9NlSgfkB2rPYjSd/EZDoQcsXzwYAv4CIB/vi3ZSvZ2Tjax5W5Ie1NMy4HG3PVdcL4bBMMR20Ng4UcISMzqRLw==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -2030,19 +1724,117 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "dependencies": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -2052,6 +1844,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
@@ -2076,6 +1877,47 @@
         "svelte": "^3.2.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -2086,6 +1928,95 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.69.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.69.0.tgz",
+      "integrity": "sha512-kjER91tHyek8gAkuz7+558vSnTQ+pITEok1P0aNOS45ZXyngaqPsXJmSel4QPQnJo7EJMjXUU1/GErWkWiKORg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sade": {
@@ -2100,13 +2031,28 @@
         "node": ">=6"
       }
     },
-    "node_modules/sade/node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+    "node_modules/sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
       "dev": true,
-      "engines": {
-        "node": ">=4"
+      "dependencies": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/sander/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/semver": {
@@ -2124,23 +2070,50 @@
         "node": ">=10"
       }
     },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "dependencies": {
-        "yallist": "^4.0.0"
+        "shebang-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       }
     },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      },
+      "bin": {
+        "sorcery": "bin/index.js"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.3",
@@ -2158,6 +2131,72 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svelte": {
@@ -2267,228 +2306,23 @@
         }
       }
     },
-    "node_modules/svelte-preprocess/node_modules/@types/pug": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
-      "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "node_modules/svelte-preprocess/node_modules/@types/sass": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
-      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "is-number": "^7.0.0"
       },
       "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=8.0"
       }
-    },
-    "node_modules/svelte-preprocess/node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/sander": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "^3.1.2",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.2"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/sorcery": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "^0.2.5",
-        "minimist": "^1.2.0",
-        "sander": "^0.5.0",
-        "sourcemap-codec": "^1.3.0"
-      },
-      "bin": {
-        "sorcery": "bin/index.js"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
-    },
-    "node_modules/svelte-preprocess/node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
     },
     "node_modules/tslib": {
       "version": "2.3.1",
@@ -2517,10 +2351,34 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2530,10 +2388,25 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
     "node_modules/vite": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.4.tgz",
-      "integrity": "sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.6.tgz",
+      "integrity": "sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.14",
@@ -2567,19 +2440,488 @@
         }
       }
     },
-    "node_modules/vite/node_modules/esbuild": {
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@eslint/eslintrc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@sveltejs/vite-plugin-svelte": {
+      "version": "1.0.0-next.39",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.39.tgz",
+      "integrity": "sha512-gnvvcAW2LK+KnUn8lKb2ypcXKwSp2K57mem5C4VNKfjxdRpM6+XwNavWwVf6otnDhz3qPYl/TKKW6/dRr6eeAw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.1.2",
+        "debug": "^4.3.3",
+        "kleur": "^4.1.4",
+        "magic-string": "^0.25.7",
+        "svelte-hmr": "^0.14.9"
+      }
+    },
+    "@tsconfig/svelte": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-2.0.1.tgz",
+      "integrity": "sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A==",
+      "dev": true
+    },
+    "@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
+    },
+    "@types/pug": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
+      "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
+      "dev": true
+    },
+    "@types/sass": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
+      "integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/type-utils": "5.13.0",
+        "@typescript-eslint/utils": "5.13.0",
+        "debug": "^4.3.2",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
+      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
+        "debug": "^4.3.2"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
+      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
+      "integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.13.0",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
+      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
+      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
+      "integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
+      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.13.0",
+        "eslint-visitor-keys": "^3.0.0"
+      }
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
+    },
+    "esbuild": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.23.tgz",
       "integrity": "sha512-XjnIcZ9KB6lfonCa+jRguXyRYcldmkyZ99ieDksqW/C8bnyEX299yA4QH2XcgijCgaddEZePPTgvx/2imsq7Ig==",
       "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
+      "requires": {
         "esbuild-android-arm64": "0.14.23",
         "esbuild-darwin-64": "0.14.23",
         "esbuild-darwin-arm64": "0.14.23",
@@ -2601,910 +2943,82 @@
         "esbuild-windows-arm64": "0.14.23"
       }
     },
-    "node_modules/vite/node_modules/esbuild-android-arm64": {
+    "esbuild-android-arm64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.23.tgz",
       "integrity": "sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==",
-      "cpu": [
-        "arm64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-darwin-64": {
+    "esbuild-darwin-64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.23.tgz",
       "integrity": "sha512-lB0XRbtOYYL1tLcYw8BoBaYsFYiR48RPrA0KfA/7RFTr4MV7Bwy/J4+7nLsVnv9FGuQummM3uJ93J3ptaTqFug==",
-      "cpu": [
-        "x64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-darwin-arm64": {
+    "esbuild-darwin-arm64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.23.tgz",
       "integrity": "sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==",
-      "cpu": [
-        "arm64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-freebsd-64": {
+    "esbuild-freebsd-64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.23.tgz",
       "integrity": "sha512-/1xiTjoLuQ+LlbfjJdKkX45qK/M7ARrbLmyf7x3JhyQGMjcxRYVR6Dw81uH3qlMHwT4cfLW4aEVBhP1aNV7VsA==",
-      "cpu": [
-        "x64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-freebsd-arm64": {
+    "esbuild-freebsd-arm64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.23.tgz",
       "integrity": "sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==",
-      "cpu": [
-        "arm64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-linux-32": {
+    "esbuild-linux-32": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.23.tgz",
       "integrity": "sha512-37R/WMkQyUfNhbH7aJrr1uCjDVdnPeTHGeDhZPUNhfoHV0lQuZNCKuNnDvlH/u/nwIYZNdVvz1Igv5rY/zfrzQ==",
-      "cpu": [
-        "ia32"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-linux-64": {
+    "esbuild-linux-64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.23.tgz",
       "integrity": "sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==",
-      "cpu": [
-        "x64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-linux-arm": {
+    "esbuild-linux-arm": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.23.tgz",
       "integrity": "sha512-x64CEUxi8+EzOAIpCUeuni0bZfzPw/65r8tC5cy5zOq9dY7ysOi5EVQHnzaxS+1NmV+/RVRpmrzGw1QgY2Xpmw==",
-      "cpu": [
-        "arm"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-linux-arm64": {
+    "esbuild-linux-arm64": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.23.tgz",
       "integrity": "sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==",
-      "cpu": [
-        "arm64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-linux-mips64le": {
+    "esbuild-linux-mips64le": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.23.tgz",
       "integrity": "sha512-kHKyKRIAedYhKug2EJpyJxOUj3VYuamOVA1pY7EimoFPzaF3NeY7e4cFBAISC/Av0/tiV0xlFCt9q0HJ68IBIw==",
-      "cpu": [
-        "mips64el"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "optional": true
     },
-    "node_modules/vite/node_modules/esbuild-linux-ppc64le": {
+    "esbuild-linux-ppc64le": {
       "version": "0.14.23",
       "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.23.tgz",
       "integrity": "sha512-7ilAiJEPuJJnJp/LiDO0oJm5ygbBPzhchJJh9HsHZzeqO+3PUzItXi+8PuicY08r0AaaOe25LA7sGJ0MzbfBag==",
-      "cpu": [
-        "ppc64"
-      ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-netbsd-64": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
-      "integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-openbsd-64": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
-      "integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-sunos-64": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
-      "integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-windows-32": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
-      "integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-windows-64": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
-      "integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild-windows-arm64": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
-      "integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/vite/node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "node_modules/vite/node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/vite/node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/vite/node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "node_modules/vite/node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.8.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/vite/node_modules/rollup": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
-      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/vite/node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    }
-  },
-  "dependencies": {
-    "@rollup/pluginutils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-          "dev": true
-        }
-      }
-    },
-    "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.37",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.37.tgz",
-      "integrity": "sha512-EdSXw2rXeOahNrQfMJVZxa/NxZxW1a0TiBI3s+pVxnxU14hEQtnkLtdbTFhnceu22gJpNPFSIJRcIwRBBDQIeA==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^4.1.2",
-        "debug": "^4.3.3",
-        "kleur": "^4.1.4",
-        "magic-string": "^0.25.7",
-        "svelte-hmr": "^0.14.9"
-      }
-    },
-    "@tsconfig/svelte": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-2.0.1.tgz",
-      "integrity": "sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A==",
-      "dev": true
-    },
-    "@types/node": {
-      "dev": true
-    },
-    "@typescript-eslint/eslint-plugin": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-      "integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/type-utils": "5.12.1",
-        "@typescript-eslint/utils": "5.12.1",
-        "debug": "^4.3.2",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/parser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-      "integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
-        "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-          "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-          "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.12.1",
-            "@typescript-eslint/visitor-keys": "5.12.1",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-          "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.12.1",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        },
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        },
-        "globby": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.9",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^3.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "merge2": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-      "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1"
-      },
-      "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-          "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
-          "dev": true
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-          "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.12.1",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        }
-      }
-    },
-    "@typescript-eslint/type-utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-      "integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/utils": "5.12.1",
-        "debug": "^4.3.2",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-      "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "@types/json-schema": {
-          "version": "7.0.9",
-          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-          "dev": true
-        },
-        "@typescript-eslint/types": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-          "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-          "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.12.1",
-            "@typescript-eslint/visitor-keys": "5.12.1",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.12.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-          "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.12.1",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        },
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-              "dev": true
-            }
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        },
-        "esrecurse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-          "dev": true,
-          "requires": {
-            "estraverse": "^5.2.0"
-          },
-          "dependencies": {
-            "estraverse": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-              "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-              "dev": true
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        },
-        "globby": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.9",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^3.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "merge2": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
-      }
-    },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-          "dev": true
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "dev": true,
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-          "dev": true
-        },
-        "readdirp": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
-      }
-    },
-    "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
+      "optional": true
     },
     "esbuild-linux-riscv64": {
       "version": "0.14.23",
@@ -3520,13 +3034,61 @@
       "dev": true,
       "optional": true
     },
+    "esbuild-netbsd-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
+      "integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
+      "integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
+      "integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
+      "integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
+      "integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
+      "integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
+      "dev": true,
+      "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
     "eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3563,173 +3125,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "@eslint/eslintrc": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-          "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.4",
-            "debug": "^4.3.2",
-            "espree": "^9.3.1",
-            "globals": "^13.9.0",
-            "ignore": "^4.0.6",
-            "import-fresh": "^3.2.1",
-            "js-yaml": "^4.1.0",
-            "minimatch": "^3.0.4",
-            "strip-json-comments": "^3.1.1"
-          },
-          "dependencies": {
-            "ignore": {
-              "version": "4.0.6",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-              "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-              "dev": true
-            }
-          }
-        },
-        "@humanwhocodes/config-array": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-          "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-          "dev": true,
-          "requires": {
-            "@humanwhocodes/object-schema": "^1.2.1",
-            "debug": "^4.1.1",
-            "minimatch": "^3.0.4"
-          }
-        },
-        "@humanwhocodes/object-schema": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-          "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-          "dev": true
-        },
-        "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-          "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-          "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-          "dev": true
-        },
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        },
         "eslint-scope": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -3740,402 +3135,10 @@
             "estraverse": "^5.2.0"
           }
         },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-              "dev": true
-            }
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        },
-        "espree": {
-          "version": "9.3.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-          "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-          "dev": true,
-          "requires": {
-            "acorn": "^8.7.0",
-            "acorn-jsx": "^5.3.1",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        },
-        "esquery": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-          "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-          "dev": true,
-          "requires": {
-            "estraverse": "^5.1.0"
-          }
-        },
-        "esrecurse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-          "dev": true,
-          "requires": {
-            "estraverse": "^5.2.0"
-          }
-        },
         "estraverse": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-          "dev": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-          "dev": true
-        },
-        "file-entry-cache": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-          "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-          "dev": true,
-          "requires": {
-            "flat-cache": "^3.0.4"
-          }
-        },
-        "flat-cache": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-          "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-          "dev": true,
-          "requires": {
-            "flatted": "^3.1.0",
-            "rimraf": "^3.0.2"
-          }
-        },
-        "flatted": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-          "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-          "dev": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.3"
-          }
-        },
-        "globals": {
-          "version": "13.12.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.20.2"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
-        "json-stable-stringify-without-jsonify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-          "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-          "dev": true
-        },
-        "levn": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "^1.2.1",
-            "type-check": "~0.4.0"
-          }
-        },
-        "lodash.merge": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "natural-compare": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "optionator": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-          "dev": true,
-          "requires": {
-            "deep-is": "^0.1.3",
-            "fast-levenshtein": "^2.0.6",
-            "levn": "^0.4.1",
-            "prelude-ls": "^1.2.1",
-            "type-check": "^0.4.0",
-            "word-wrap": "^1.2.3"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "prelude-ls": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-          "dev": true
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-          "dev": true
-        },
-        "type-check": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "^1.2.1"
-          }
-        },
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "v8-compile-cache": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-          "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "word-wrap": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -4146,6 +3149,108 @@
       "integrity": "sha512-7p59WG8qV8L6wLdl4d/c3mdjkgVglQCdv5XOTk/iNPBKXuuV+Q0eFP5Wa6iJd/G2M1qR3BkLPEzaANOqKAZczw==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -4160,59 +3265,6 @@
         "micromatch": "^4.0.4"
       },
       "dependencies": {
-        "@nodelib/fs.scandir": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-          "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "2.0.5",
-            "run-parallel": "^1.1.9"
-          }
-        },
-        "@nodelib/fs.stat": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-          "dev": true
-        },
-        "@nodelib/fs.walk": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-          "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.scandir": "2.1.5",
-            "fastq": "^1.6.0"
-          }
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fastq": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-          "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-          "dev": true,
-          "requires": {
-            "reusify": "^1.0.4"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
         "glob-parent": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -4221,86 +3273,154 @@
           "requires": {
             "is-glob": "^4.0.1"
           }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "merge2": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-          "dev": true
-        },
-        "queue-microtask": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-          "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-          "dev": true
-        },
-        "reusify": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-          "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-          "dev": true
-        },
-        "run-parallel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-          "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-          "dev": true,
-          "requires": {
-            "queue-microtask": "^1.2.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
         }
       }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "13.12.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "ignore": {
@@ -4317,30 +3437,95 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-          "dev": true
-        },
-        "parent-module": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-          "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-          "dev": true,
-          "requires": {
-            "callsites": "^3.0.0"
-          }
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
-        }
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "kleur": {
       "version": "4.1.4",
@@ -4348,21 +3533,69 @@
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "dev": true
     },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
-      },
-      "dependencies": {
-        "sourcemap-codec": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-          "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-          "dev": true
-        }
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.8.tgz",
+      "integrity": "sha512-n9NlSgfkB2rPYjSd/EZDoQcsXzwYAv4CIB/vi3ZSvZ2Tjax5W5Ie1NMy4HG3PVdcL4bBMMR20Ng4UcISMzqRLw==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4371,10 +3604,99 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
       "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "picocolors": {
@@ -4383,16 +3705,28 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
     "postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
     },
     "prettier": {
       "version": "2.5.1",
@@ -4407,11 +3741,82 @@
       "dev": true,
       "requires": {}
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.69.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.69.0.tgz",
+      "integrity": "sha512-kjER91tHyek8gAkuz7+558vSnTQ+pITEok1P0aNOS45ZXyngaqPsXJmSel4QPQnJo7EJMjXUU1/GErWkWiKORg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "sade": {
       "version": "1.8.1",
@@ -4420,13 +3825,28 @@
       "dev": true,
       "requires": {
         "mri": "^1.1.0"
+      }
+    },
+    "sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
       },
       "dependencies": {
-        "mri": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-          "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-          "dev": true
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -4437,23 +3857,39 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
       }
     },
     "source-map": {
@@ -4466,6 +3902,51 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
     "svelte": {
@@ -4510,198 +3991,21 @@
         "magic-string": "^0.25.7",
         "sorcery": "^0.10.0",
         "strip-indent": "^3.0.0"
-      },
-      "dependencies": {
-        "@types/pug": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
-          "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
-          "dev": true
-        },
-        "@types/sass": {
-          "version": "1.43.1",
-          "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
-          "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-crc32": {
-          "version": "0.2.13",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-          "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-          "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-          "dev": true
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-          "dev": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.9",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-          "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
-        },
-        "min-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-          "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "sander": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-          "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
-          "dev": true,
-          "requires": {
-            "es6-promise": "^3.1.2",
-            "graceful-fs": "^4.1.3",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.2"
-          }
-        },
-        "sorcery": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-          "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
-          "dev": true,
-          "requires": {
-            "buffer-crc32": "^0.2.5",
-            "minimist": "^1.2.0",
-            "sander": "^0.5.0",
-            "sourcemap-codec": "^1.3.0"
-          }
-        },
-        "sourcemap-codec": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-          "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-          "dev": true
-        },
-        "strip-indent": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-          "dev": true,
-          "requires": {
-            "min-indent": "^1.0.0"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "tslib": {
@@ -4727,16 +4031,46 @@
         }
       }
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "vite": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.4.tgz",
-      "integrity": "sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.6.tgz",
+      "integrity": "sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.14",
@@ -4744,218 +4078,34 @@
         "postcss": "^8.4.6",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
-      },
-      "dependencies": {
-        "esbuild": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.23.tgz",
-          "integrity": "sha512-XjnIcZ9KB6lfonCa+jRguXyRYcldmkyZ99ieDksqW/C8bnyEX299yA4QH2XcgijCgaddEZePPTgvx/2imsq7Ig==",
-          "dev": true,
-          "requires": {
-            "esbuild-android-arm64": "0.14.23",
-            "esbuild-darwin-64": "0.14.23",
-            "esbuild-darwin-arm64": "0.14.23",
-            "esbuild-freebsd-64": "0.14.23",
-            "esbuild-freebsd-arm64": "0.14.23",
-            "esbuild-linux-32": "0.14.23",
-            "esbuild-linux-64": "0.14.23",
-            "esbuild-linux-arm": "0.14.23",
-            "esbuild-linux-arm64": "0.14.23",
-            "esbuild-linux-mips64le": "0.14.23",
-            "esbuild-linux-ppc64le": "0.14.23",
-            "esbuild-linux-riscv64": "0.14.23",
-            "esbuild-linux-s390x": "0.14.23",
-            "esbuild-netbsd-64": "0.14.23",
-            "esbuild-openbsd-64": "0.14.23",
-            "esbuild-sunos-64": "0.14.23",
-            "esbuild-windows-32": "0.14.23",
-            "esbuild-windows-64": "0.14.23",
-            "esbuild-windows-arm64": "0.14.23"
-          }
-        },
-        "esbuild-android-arm64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.23.tgz",
-          "integrity": "sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-darwin-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.23.tgz",
-          "integrity": "sha512-lB0XRbtOYYL1tLcYw8BoBaYsFYiR48RPrA0KfA/7RFTr4MV7Bwy/J4+7nLsVnv9FGuQummM3uJ93J3ptaTqFug==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-darwin-arm64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.23.tgz",
-          "integrity": "sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-freebsd-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.23.tgz",
-          "integrity": "sha512-/1xiTjoLuQ+LlbfjJdKkX45qK/M7ARrbLmyf7x3JhyQGMjcxRYVR6Dw81uH3qlMHwT4cfLW4aEVBhP1aNV7VsA==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-freebsd-arm64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.23.tgz",
-          "integrity": "sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-linux-32": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.23.tgz",
-          "integrity": "sha512-37R/WMkQyUfNhbH7aJrr1uCjDVdnPeTHGeDhZPUNhfoHV0lQuZNCKuNnDvlH/u/nwIYZNdVvz1Igv5rY/zfrzQ==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-linux-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.23.tgz",
-          "integrity": "sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-linux-arm": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.23.tgz",
-          "integrity": "sha512-x64CEUxi8+EzOAIpCUeuni0bZfzPw/65r8tC5cy5zOq9dY7ysOi5EVQHnzaxS+1NmV+/RVRpmrzGw1QgY2Xpmw==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-linux-arm64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.23.tgz",
-          "integrity": "sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-linux-mips64le": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.23.tgz",
-          "integrity": "sha512-kHKyKRIAedYhKug2EJpyJxOUj3VYuamOVA1pY7EimoFPzaF3NeY7e4cFBAISC/Av0/tiV0xlFCt9q0HJ68IBIw==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-linux-ppc64le": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.23.tgz",
-          "integrity": "sha512-7ilAiJEPuJJnJp/LiDO0oJm5ygbBPzhchJJh9HsHZzeqO+3PUzItXi+8PuicY08r0AaaOe25LA7sGJ0MzbfBag==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-netbsd-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
-          "integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-openbsd-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
-          "integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-sunos-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
-          "integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-windows-32": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
-          "integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-windows-64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
-          "integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
-          "dev": true,
-          "optional": true
-        },
-        "esbuild-windows-arm64": {
-          "version": "0.14.23",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
-          "integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
-          "dev": true,
-          "optional": true
-        },
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "is-core-module": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "path-parse": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.8.1",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
-        },
-        "rollup": {
-          "version": "2.68.0",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
-          "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
-          "dev": true,
-          "requires": {
-            "fsevents": "~2.3.2"
-          }
-        },
-        "supports-preserve-symlinks-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-          "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-          "dev": true
-        }
       }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   }
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,27 +11,42 @@
     return value === null || value.trim()?.length === 0
   }
 
+  //  type ResourceRequest = {
+  //    lang_code: string
+  //    resource_type: string
+  //    resource_code: string
+  //  }
+  //
+  //  type DocumentRequest = {
+  //    email_address: string | null | undefined
+  //    assembly_strategy_kind: AssemblyStrategy | null
+  //    assembly_layout_kind: null | undefined
+  //    layout_for_print: boolean
+  //    resource_requests: Array<ResourceRequest>
+  //  }
+
   let email: string | null = null
   let assemblyStrategy: AssemblyStrategy | null
+  let layoutForPrint: boolean | null
   let lang0Code: string = ''
   let lang0ResourceTypes: string[] = []
   let lang0ResourceCodes: string[] = []
   let lang1Code: string = ''
   let lang1ResourceTypes: string[] = []
   let lang1ResourceCodes: string[] = []
-  let lang2Code: string = ''
-  let lang2ResourceTypes: string[] = []
-  let lang2ResourceCodes: string[] = []
+  /* let lang2Code: string = '' */
+  /* let lang2ResourceTypes: string[] = [] */
+  /* let lang2ResourceCodes: string[] = [] */
 
   // Button will toggle this value
   let showAnotherLang: boolean = false
   function handleAddLang() {
     showAnotherLang = true
   }
-  let showAnotherLang2: boolean = false
-  function handleAddLang2() {
-    showAnotherLang2 = true
-  }
+  /* let showAnotherLang2: boolean = false */
+  /* function handleAddLang2() { */
+  /*   showAnotherLang2 = true */
+  /* } */
 
   onMount(() => {
     reset()
@@ -107,35 +122,35 @@
 
   // Language 2
 
-  async function getLang2CodesAndNames(): Promise<string[]> {
-    const response = await fetch(API_ROOT_URL + LANGUAGE_CODES_AND_NAMES)
-    const json = await response.json()
-    if (response.ok) {
-      return <string[]>json
-    } else {
-      throw new Error(json)
-    }
-  }
+  /* async function getLang2CodesAndNames(): Promise<string[]> { */
+  /*   const response = await fetch(API_ROOT_URL + LANGUAGE_CODES_AND_NAMES) */
+  /*   const json = await response.json() */
+  /*   if (response.ok) { */
+  /*     return <string[]>json */
+  /*   } else { */
+  /*     throw new Error(json) */
+  /*   } */
+  /* } */
 
-  async function getLang2ResourceTypes(langCode: string): Promise<string[]> {
-    const response = await fetch(API_ROOT_URL + RESOURCE_TYPES_FOR_LANG + langCode)
-    const json = await response.json()
-    if (response.ok) {
-      return <string[]>json
-    } else {
-      throw new Error(json)
-    }
-  }
+  /* async function getLang2ResourceTypes(langCode: string): Promise<string[]> { */
+  /*   const response = await fetch(API_ROOT_URL + RESOURCE_TYPES_FOR_LANG + langCode) */
+  /*   const json = await response.json() */
+  /*   if (response.ok) { */
+  /*     return <string[]>json */
+  /*   } else { */
+  /*     throw new Error(json) */
+  /*   } */
+  /* } */
 
-  async function getLang2ResourceCodes(langCode: string): Promise<string[]> {
-    const response = await fetch(API_ROOT_URL + RESOURCE_CODES_FOR_LANG + langCode)
-    const json = await response.json()
-    if (response.ok) {
-      return <string[]>json
-    } else {
-      throw new Error(json)
-    }
-  }
+  /* async function getLang2ResourceCodes(langCode: string): Promise<string[]> { */
+  /*   const response = await fetch(API_ROOT_URL + RESOURCE_CODES_FOR_LANG + langCode) */
+  /*   const json = await response.json() */
+  /*   if (response.ok) { */
+  /*     return <string[]>json */
+  /*   } else { */
+  /*     throw new Error(json) */
+  /*   } */
+  /* } */
 
   let finished_document_url: string = ''
 
@@ -144,20 +159,21 @@
     // Be careful to set email to null as API expects a null rather
     // than empty string if email is not provided by user.
     email = null
+    layoutForPrint = null
     lang0Code = ''
     lang0ResourceTypes = []
     lang0ResourceCodes = []
     lang1Code = ''
     lang1ResourceTypes = []
     lang1ResourceCodes = []
-    lang2Code = ''
-    lang2ResourceTypes = []
-    lang2ResourceCodes = []
+    /* lang2Code = '' */
+    /* lang2ResourceTypes = [] */
+    /* lang2ResourceCodes = [] */
     hideWaitMessage()
     hideErrorMessage()
     finished_document_url = ''
     showAnotherLang = false
-    showAnotherLang2 = false
+    /* showAnotherLang2 = false */
     document.getElementById('email')?.focus()
   }
 
@@ -205,22 +221,32 @@
       }
     }
     // Create resource_requests for lang2
-    for (let resourceCode of <string[]>lang2ResourceCodes) {
-      for (let resourceType of <string[]>lang2ResourceTypes) {
-        rr.push({
-          lang_code: lang2Code,
-          resource_type: resourceType,
-          resource_code: resourceCode
-        })
-      }
-    }
+    /* for (let resourceCode of <string[]>lang2ResourceCodes) { */
+    /*   for (let resourceType of <string[]>lang2ResourceTypes) { */
+    /*     rr.push({ */
+    /*       lang_code: lang2Code, */
+    /*       resource_type: resourceType, */
+    /*       resource_code: resourceCode */
+    /*     }) */
+    /*   } */
+    /* } */
 
     console.log('email: ', email)
+    if (layoutForPrint) {
+      layoutForPrint = true
+    } else {
+      layoutForPrint = false
+    }
+
     // Create the JSON structure to POST.
+    // let documentRequest: DocumentRequest = {
     let documentRequest = {
       // FIXME Test that email_address is handled correctly with respect to null
       email_address: email?.trim(), // !isEmpty(email) ? email.trim() : null,
+      // email_address: !isEmpty(email) ? email.trim() : null,
       assembly_strategy_kind: assemblyStrategy,
+      // assembly_layout_kind: undefined,
+      layout_for_print: layoutForPrint,
       resource_requests: rr
     }
     console.log('document request: ', JSON.stringify(documentRequest, null, 2))
@@ -269,6 +295,13 @@
           <label for="email">{import.meta.env.VITE_EMAIL_LABEL}</label>
           <input type="text" name="email" id="email" bind:value={email} />
         </div>
+        <label for="layoutForPrint">{import.meta.env.VITE_LAYOUT_FOR_PRINT_LABEL}</label>
+        <input
+          type="checkbox"
+          name="layoutForPrint"
+          id="layoutForPrint"
+          bind:checked={layoutForPrint}
+        />
 
         <AssemblyStrategyComponent bind:assemblyStrategy />
 
@@ -399,12 +432,12 @@
             {/await}
           </div>
         {/if}
-        {#if !isEmpty(lang1Code) && lang1ResourceTypes?.length > 0 && lang1ResourceCodes?.length > 0}
+        <!-- {#if !isEmpty(lang1Code) && lang1ResourceTypes?.length > 0 && lang1ResourceCodes?.length > 0}
           <button disabled={showAnotherLang2} on:click|preventDefault={handleAddLang2}
             >{import.meta.env.VITE_ADD_ANOTHER_LANGUAGE_BUTTON_TXT}</button
           >
-        {/if}
-        {#if showAnotherLang2}
+        {/if} -->
+        <!-- {#if showAnotherLang2}
           <div>
             <h3>{import.meta.env.VITE_LANG_2_HEADER}</h3>
             {#await getLang2CodesAndNames()}
@@ -465,7 +498,7 @@
               <p class="error">{error.message}</p>
             {/await}
           </div>
-        {/if}
+        {/if} -->
 
         <div style="margin-top:3em">
           <button on:click|preventDefault={reset}>reset</button>
@@ -486,11 +519,18 @@
       {#if finished_document_url.length > 0}
         <div class="finished-document-url">
           <p>
-            {import.meta.env.VITE_DOCUMENT_READY_MSG_PART1}
+            {import.meta.env.VITE_PDF_DOCUMENT_READY_MSG_PART1}
             <a href="{API_ROOT_URL}/pdfs/{finished_document_url}"
-              >{import.meta.env.VITE_DOCUMENT_READY_LINK_TXT}</a
+              >{import.meta.env.VITE_PDF_DOCUMENT_READY_LINK_TXT}</a
             >
-            {import.meta.env.VITE_DOCUMENT_READY_MSG_PART2}
+            {import.meta.env.VITE_PDF_DOCUMENT_READY_MSG_PART2}
+          </p>
+          <p>
+            {import.meta.env.VITE_HTML_DOCUMENT_READY_MSG_PART1}
+            <a href="{API_ROOT_URL}/html/{finished_document_url}" target="_blank"
+              >{import.meta.env.VITE_HTML_DOCUMENT_READY_LINK_TXT}</a
+            >
+            {import.meta.env.VITE_HTML_DOCUMENT_READY_MSG_PART2}
           </p>
         </div>
       {/if}

--- a/frontend/src/lib/AssemblyStrategy.svelte
+++ b/frontend/src/lib/AssemblyStrategy.svelte
@@ -2,11 +2,11 @@
   import type { AssemblyStrategy } from './types'
 
   let book_language_order_strategy: AssemblyStrategy = {
-    id: 'book_language_order',
+    id: 'blo',
     label: <string>import.meta.env.VITE_BOOK_LANGUAGE_ORDER_LABEL
   }
   let language_book_order_strategy: AssemblyStrategy = {
-    id: 'language_book_order',
+    id: 'lbo',
     label: <string>import.meta.env.VITE_LANGUAGE_BOOK_ORDER_LABEL
   }
   let assemblyStrategies = [book_language_order_strategy, language_book_order_strategy]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import random
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Optional
 
 import pydantic
 import pytest
@@ -120,14 +120,37 @@ def random_resource_code2() -> str:
     return random.choice(book_ids)
 
 
-@pytest.fixture(params=[settings.TO_EMAIL_ADDRESS])
-def email_address(request: Any) -> Any:
-    return request.param
+@pytest.fixture()
+def email_address() -> str:
+    return settings.TO_EMAIL_ADDRESS
 
 
-@pytest.fixture(params=[model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER])
-def assembly_strategy_kind(request: Any) -> Any:
-    return request.param
+@pytest.fixture()
+def assembly_strategy_kind() -> str:
+    return random.choice(
+        [
+            model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+            model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+        ]
+    )
+
+
+@pytest.fixture
+def assembly_layout_kind() -> Optional[str]:
+    return None
+    # return random.choice(
+    #     [
+    #         model.AssemblyLayoutEnum.ONE_COLUMN,
+    #         model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+    #         model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+    #         model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+    #     ]
+    # )
+
+
+@pytest.fixture
+def layout_for_print() -> bool:
+    return random.choice([True, False])
 
 
 @pytest.fixture()
@@ -320,12 +343,16 @@ def random_non_english_resource_requests2(
 def english_document_request(
     email_address: pydantic.EmailStr,
     assembly_strategy_kind: model.AssemblyStrategyEnum,
+    assembly_layout_kind: model.AssemblyLayoutEnum,
+    layout_for_print: bool,
     english_resource_requests: Sequence[model.ResourceRequest],
 ) -> model.DocumentRequest:
     """Build one English language document request."""
     return model.DocumentRequest(
         email_address=email_address,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=layout_for_print,
         resource_requests=english_resource_requests,
     )
 
@@ -334,6 +361,8 @@ def english_document_request(
 def random_english_document_request(
     email_address: pydantic.EmailStr,
     assembly_strategy_kind: model.AssemblyStrategyEnum,
+    assembly_layout_kind: model.AssemblyLayoutEnum,
+    layout_for_print: bool,
     english_resource_requests: Sequence[model.ResourceRequest],
 ) -> model.DocumentRequest:
     """
@@ -347,6 +376,8 @@ def random_english_document_request(
     return model.DocumentRequest(
         email_address=email_address,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=layout_for_print,
         resource_requests=random_english_resource_requests,
     )
 
@@ -355,8 +386,9 @@ def random_english_document_request(
 def random_non_english_document_request(
     email_address: pydantic.EmailStr,
     assembly_strategy_kind: model.AssemblyStrategyEnum,
+    assembly_layout_kind: model.AssemblyLayoutEnum,
+    layout_for_print: bool,
     random_non_english_resource_requests: Sequence[model.ResourceRequest],
-    random_resource_code: str,
 ) -> model.DocumentRequest:
     """
     Build one non-English language document request for each
@@ -376,6 +408,8 @@ def random_non_english_document_request(
     return model.DocumentRequest(
         email_address=email_address,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=layout_for_print,
         resource_requests=random_non_english_resource_requests,
     )
 
@@ -384,8 +418,9 @@ def random_non_english_document_request(
 def random_failing_non_english_document_request(
     email_address: pydantic.EmailStr,
     assembly_strategy_kind: model.AssemblyStrategyEnum,
+    assembly_layout_kind: model.AssemblyLayoutEnum,
+    layout_for_print: bool,
     random_failing_non_english_resource_requests: Sequence[model.ResourceRequest],
-    random_resource_code: str,
 ) -> model.DocumentRequest:
     """
     Build one non-English language document request for each
@@ -408,6 +443,8 @@ def random_failing_non_english_document_request(
     return model.DocumentRequest(
         email_address=email_address,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=layout_for_print,
         resource_requests=random_failing_non_english_resource_requests,
     )
 
@@ -421,6 +458,8 @@ def random_failing_non_english_document_request(
 def random_english_and_non_english_document_request(
     email_address: pydantic.EmailStr,
     assembly_strategy_kind: model.AssemblyStrategyEnum,
+    assembly_layout_kind: model.AssemblyLayoutEnum,
+    layout_for_print: bool,
     random_english_resource_requests: Sequence[model.ResourceRequest],
     random_non_english_resource_requests: Sequence[model.ResourceRequest],
 ) -> model.DocumentRequest:
@@ -442,6 +481,8 @@ def random_english_and_non_english_document_request(
     return model.DocumentRequest(
         email_address=email_address,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=layout_for_print,
         resource_requests=[
             *random_english_resource_requests,
             *random_non_english_resource_requests,
@@ -453,6 +494,8 @@ def random_english_and_non_english_document_request(
 def random_two_non_english_languages_document_request(
     email_address: pydantic.EmailStr,
     assembly_strategy_kind: model.AssemblyStrategyEnum,
+    assembly_layout_kind: model.AssemblyLayoutEnum,
+    layout_for_print: bool,
     random_non_english_resource_requests: Sequence[model.ResourceRequest],
     random_non_english_resource_requests2: Sequence[model.ResourceRequest],
 ) -> model.DocumentRequest:
@@ -464,6 +507,8 @@ def random_two_non_english_languages_document_request(
     return model.DocumentRequest(
         email_address=email_address,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=layout_for_print,
         resource_requests=[
             *random_non_english_resource_requests,
             *random_non_english_resource_requests2,

--- a/tests/e2e/test_api_assembly_strategy_combinations_book_then_lang.py
+++ b/tests/e2e/test_api_assembly_strategy_combinations_book_then_lang.py
@@ -8690,3 +8690,125 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_c
             },
         )
         check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_en_bc_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_for_print() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": None,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "bc-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_en_bc_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_not_for_print() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": None,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "bc-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)

--- a/tests/e2e/test_api_assembly_strategy_combinations_book_then_lang.py
+++ b/tests/e2e/test_api_assembly_strategy_combinations_book_then_lang.py
@@ -8,6 +8,7 @@ import requests
 from fastapi.testclient import TestClient
 
 from document.config import settings
+from document.domain import model
 from document.entrypoints.app import app
 
 ##################################################
@@ -107,13 +108,15 @@ def check_finished_document_without_verses_success(response: requests.Response) 
     assert response.ok
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_hr() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -161,13 +164,295 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_c
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -215,13 +500,295 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_b
         check_finished_document_with_verses_success(response)
 
 
-def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "pt-br",
@@ -249,13 +816,195 @@ def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_orde
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order() -> None:
+def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_pt_br_ulb_col_pt_br_tn_col_pt_br_tq_col_pt_br_tw_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -283,13 +1032,195 @@ def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order() -> None:
+def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -342,14 +1273,321 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_c
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order_2c_sl_hr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_tl_ulb_col_tl_tn_col_tl_tq_col_tl_tw_col_tl_udb_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order_2c_sl_hr() -> None:
     "English ulb-wa and tn-wa for book of Timothy."
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -364,24 +1602,153 @@ def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order() -> None:
                 ],
             },
         )
-        finished_document_name = "en-ulb-wa-tit_en-tn-wa-tit_book_language_order.pdf"
-        finished_document_path = os.path.join(
-            settings.output_dir(), finished_document_name
-        )
-        assert os.path.isfile(finished_document_path)
-        assert response.json() == {
-            "finished_document_request_key": pathlib.Path(finished_document_path).stem,
-            "message": settings.SUCCESS_MESSAGE,
-        }
+        check_finished_document_with_verses_success(response)
 
 
-def test_sw_ulb_col_sw_tn_col_book_language_order() -> None:
+def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order_2c_sl_hr_c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order_2c_sl_sr() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order_2c_sl_sr_c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order_1c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_book_language_order_1c_c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": True,
                 "resource_requests": [
                     {
                         "lang_code": "sw",
@@ -399,13 +1766,145 @@ def test_sw_ulb_col_sw_tn_col_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order() -> None:
+def test_sw_ulb_col_sw_tn_col_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "sw",
@@ -433,13 +1932,159 @@ def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order() -> None:
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -477,13 +2122,245 @@ def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_bo
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -536,13 +2413,320 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -580,13 +2764,245 @@ def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_bo
         check_finished_document_with_verses_success(response)
 
 
-def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_tn_tit_sw_tq_tit_sw_tw_tit_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order_2c_sl_sr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order_2c_sl_sr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_SCRIPTURE_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_tn_tit_sw_tq_tit_sw_tw_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -639,13 +3055,76 @@ def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw
         check_finished_document_with_body_success(response)
 
 
-def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_book_language_order() -> None:
+def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_tn_tit_sw_tq_tit_sw_tw_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -683,13 +3162,61 @@ def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_book_
         check_finished_document_with_body_success(response)
 
 
-def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_book_language_order() -> None:
+def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -717,13 +3244,51 @@ def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_book_
         check_finished_document_with_body_success(response)
 
 
-def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_book_language_order() -> None:
+def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -741,13 +3306,41 @@ def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_book_language_order() -> None:
         check_finished_document_with_body_success(response)
 
 
-def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_book_language_order() -> None:
+def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -775,13 +3368,51 @@ def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_book_
         check_finished_document_with_body_success(response)
 
 
-def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_book_language_order() -> None:
+def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -799,13 +3430,41 @@ def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_book_language_order() -> None:
         check_finished_document_with_body_success(response)
 
 
-def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_book_language_order() -> None:
+def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -828,13 +3487,46 @@ def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_book_language_order() -> None:
         check_finished_document_with_body_success(response)
 
 
-def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_book_language_order() -> None:
+def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_book_language_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_body_success(response)
+
+
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -857,13 +3549,108 @@ def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_book_language_order() -> None:
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "gu",
@@ -896,13 +3683,138 @@ def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_book_language_order
         check_finished_document_with_verses_success(response)
 
 
-def test_ceb_ulb_mrk_ceb_tw_mrk_ceb_tq_mrk_ceb_tn_mrk_fr_ulb_mrk_fr_tw_mrk_fr_tq_mrk_fr_tn_mrk_fr_f10_mrk_pt_br_ulb_mrk_pt_br_tw_mrk_pt_br_tq_mrk_pt_br_tn_mrk_book_language_order() -> None:
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_ceb_ulb_mrk_ceb_tw_mrk_ceb_tq_mrk_ceb_tn_mrk_fr_ulb_mrk_fr_tw_mrk_fr_tq_mrk_fr_tn_mrk_fr_f10_mrk_pt_br_ulb_mrk_pt_br_tw_mrk_pt_br_tq_mrk_pt_br_tn_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "ceb",
@@ -975,13 +3887,258 @@ def test_ceb_ulb_mrk_ceb_tw_mrk_ceb_tq_mrk_ceb_tn_mrk_fr_ulb_mrk_fr_tw_mrk_fr_tq
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order() -> None:
+def test_ceb_ulb_mrk_ceb_tw_mrk_ceb_tq_mrk_ceb_tn_mrk_fr_ulb_mrk_fr_tw_mrk_fr_tq_mrk_fr_tn_mrk_fr_f10_mrk_pt_br_ulb_mrk_pt_br_tw_mrk_pt_br_tq_mrk_pt_br_tn_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_ceb_ulb_mrk_ceb_tw_mrk_ceb_tq_mrk_ceb_tn_mrk_fr_ulb_mrk_fr_tw_mrk_fr_tq_mrk_fr_tn_mrk_fr_f10_mrk_pt_br_ulb_mrk_pt_br_tw_mrk_pt_br_tq_mrk_pt_br_tn_mrk_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_ceb_ulb_mrk_ceb_tw_mrk_ceb_tq_mrk_ceb_tn_mrk_fr_ulb_mrk_fr_tw_mrk_fr_tq_mrk_fr_tn_mrk_fr_f10_mrk_pt_br_ulb_mrk_pt_br_tw_mrk_pt_br_tq_mrk_pt_br_tn_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "ceb",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -1014,13 +4171,138 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -1048,13 +4330,123 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -1082,13 +4474,123 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_book_language_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -1111,13 +4613,108 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -1140,40 +4737,30 @@ def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-# Skipping because TA resource type not supported yet.
-@pytest.mark.skip
-def test_gu_ulb_mic_gu_tn_mic_gu_tq_mic_gu_tw_mic_gu_ta_mic_book_language_order() -> None:
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
                 "resource_requests": [
                     {
-                        "lang_code": "gu",
+                        "lang_code": "mr",
                         "resource_type": "ulb",
-                        "resource_code": "mic",
+                        "resource_code": "mrk",
                     },
                     {
-                        "lang_code": "gu",
-                        "resource_type": "tn",
-                        "resource_code": "mic",
-                    },
-                    {
-                        "lang_code": "gu",
+                        "lang_code": "mr",
                         "resource_type": "tq",
-                        "resource_code": "mic",
+                        "resource_code": "mrk",
                     },
                     {
-                        "lang_code": "gu",
-                        "resource_type": "tw",
-                        "resource_code": "mic",
-                    },
-                    {
-                        "lang_code": "gu",
-                        "resource_type": "ta",
-                        "resource_code": "mic",
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
                     },
                 ],
             },
@@ -1181,13 +4768,77 @@ def test_gu_ulb_mic_gu_tn_mic_gu_tq_mic_gu_tw_mic_gu_ta_mic_book_language_order(
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_ulb_gen_tl_udb_gen_book_language_order() -> None:
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_1c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_ulb_gen_tl_udb_gen_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -1205,13 +4856,93 @@ def test_tl_ulb_gen_tl_udb_gen_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_book_language_order() -> None:
+def test_tl_ulb_gen_tl_udb_gen_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_ulb_gen_tl_udb_gen_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_ulb_gen_tl_udb_gen_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "gu",
@@ -1239,13 +4970,123 @@ def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_book_language_order() -> None:
+def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "gu",
@@ -1268,13 +5109,108 @@ def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_book_language_order() -> None:
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -1297,13 +5233,108 @@ def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_tq_gen_tl_udb_gen_book_language_order() -> None:
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tq_gen_tl_udb_gen_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -1321,13 +5352,93 @@ def test_tl_tq_gen_tl_udb_gen_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_tw_gen_tl_udb_gen_book_language_order() -> None:
+def test_tl_tq_gen_tl_udb_gen_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tq_gen_tl_udb_gen_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tq_gen_tl_udb_gen_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tw_gen_tl_udb_gen_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -1345,13 +5456,93 @@ def test_tl_tw_gen_tl_udb_gen_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_udb_gen_book_language_order() -> None:
+def test_tl_tw_gen_tl_udb_gen_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tw_gen_tl_udb_gen_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tw_gen_tl_udb_gen_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_udb_gen_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -1364,14 +5555,79 @@ def test_tl_udb_gen_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_book_language_order() -> None:
+def test_tl_udb_gen_book_language_order_2c_sl_hr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_udb_gen_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_udb_gen_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_book_language_order_2c_sl_hr() -> None:
     """Demonstrate listing unfound resources, in this case fr-udb-rev"""
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1404,7 +5660,133 @@ def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_book_language_order
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order() -> None:
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_book_language_order_2c_sl_hr_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "udb",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_book_language_order_1c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "udb",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_book_language_order_1c_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "udb",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_2c_sl_hr() -> None:
     """
     Demonstrate two USFM resources, French, and use of a special
     USFM resource: f10.
@@ -1414,7 +5796,9 @@ def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1447,7 +5831,7 @@ def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order() -> None:
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_2c_sl_hr_c() -> None:
     """
     Demonstrate two USFM resources, French, and use of a special
     USFM resource: f10.
@@ -1457,7 +5841,144 @@ def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order() -> None
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_1c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_1c_c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_2c_sl_hr() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1485,14 +6006,136 @@ def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_book_language_order() -> None:
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_2c_sl_hr_c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_1c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_book_language_order_1c_c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_book_language_order_2c_sl_hr() -> None:
     """Demonstrate listing unfound resources, in this case fr-udb-rev"""
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1515,7 +6158,103 @@ def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_book_language_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_x_chindali_tw_mat_ndh_x_chindali_udb_mat_book_language_order() -> None:
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_book_language_order_2c_sl_hr_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_book_language_order_1c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_book_language_order_1c_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_x_chindali_tw_mat_ndh_x_chindali_udb_mat_book_language_order_2c_sl_hr() -> None:
     """
     Show that the succeeding resource request's, fr-f10-rev,
     content is rendered and the failing resource requests are reported
@@ -1526,7 +6265,9 @@ def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_t
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1572,6 +6313,186 @@ def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_t
             },
         )
 
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_x_chindali_tw_mat_ndh_x_chindali_udb_mat_book_language_order_2c_sl_hr_c() -> None:
+    """
+    Show that the succeeding resource request's, fr-f10-rev,
+    content is rendered and the failing resource requests are reported
+    on the cover page of the PDF.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "reg",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_x_chindali_tw_mat_ndh_x_chindali_udb_mat_book_language_order_1c() -> None:
+    """
+    Show that the succeeding resource request's, fr-f10-rev,
+    content is rendered and the failing resource requests are reported
+    on the cover page of the PDF.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "reg",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_x_chindali_tw_mat_ndh_x_chindali_udb_mat_book_language_order_1c_c() -> None:
+    """
+    Show that the succeeding resource request's, fr-f10-rev,
+    content is rendered and the failing resource requests are reported
+    on the cover page of the PDF.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "reg",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "ndh-x-chindali",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
         check_finished_document_with_verses_success(response)
 
 
@@ -1588,7 +6509,9 @@ def test_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "ndh-x-chindali",
@@ -1621,13 +6544,15 @@ def test_ndh_x_chindali_reg_mat_ndh_x_chindali_tn_mat_ndh_x_chindali_tq_mat_ndh_
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_2c_sl_hr() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -1675,7 +6600,175 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_
         check_finished_document_with_verses_success(response)
 
 
-def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_2c_sl_hr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order_2c_sl_hr() -> None:
     """
     Ask for a combination of available and unavailable resources.
     """
@@ -1684,7 +6777,9 @@ def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order() -> None:
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "es",
@@ -1712,7 +6807,124 @@ def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order() -> None:
         check_finished_document_without_verses_success(response)
 
 
-def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order() -> None:
+def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order_2c_sl_hr_c() -> None:
+    """
+    Ask for a combination of available and unavailable resources.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "es",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order_1c() -> None:
+    """
+    Ask for a combination of available and unavailable resources.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "es",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_es_ulb_col_es_tn_col_en_tq_col_es_tw_col_book_language_order_1c_c() -> None:
+    """
+    Ask for a combination of available and unavailable resources.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "es",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_2c_sl_hr() -> None:
     """
     Ask for an unavailable resource and assert that the verses_html is
     not generated.
@@ -1722,7 +6934,9 @@ def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order() -> No
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "llx",
@@ -1750,7 +6964,7 @@ def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order() -> No
         check_finished_document_without_verses_success(response)
 
 
-def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order() -> None:
+def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_2c_sl_hr_c() -> None:
     """
     Ask for an unavailable resource and assert that the verses_html is
     not generated.
@@ -1760,7 +6974,129 @@ def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order() -> No
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_1c() -> None:
+    """
+    Ask for an unavailable resource and assert that the verses_html is
+    not generated.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_llx_ulb_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_1c_c() -> None:
+    """
+    Ask for an unavailable resource and assert that the verses_html is
+    not generated.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_2c_sl_hr() -> None:
+    """
+    Ask for an unavailable resource and assert that the verses_html is
+    not generated.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "llx",
@@ -1785,35 +7121,138 @@ def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order() -> No
                 ],
             },
         )
-        finished_document_name = (
-            "llx-reg-col_llx-tn-col_llx-tq-col_llx-tw-col_book_language_order.pdf"
-        )
-        finished_document_path = os.path.join(
-            settings.output_dir(), finished_document_name
-        )
-        html_file = "{}.html".format(finished_document_path.split(".")[0])
-        assert os.path.exists(finished_document_path)
-        assert os.path.exists(html_file)
-        assert response.ok
-        with open(html_file, "r") as fin:
-            html = fin.read()
-            parser = bs4.BeautifulSoup(html, "html.parser")
-            body = parser.find_all("body")
-            assert body
-            verses_html = parser.find_all("span", attrs={"class": "v-num"})
-            # Resource requested doesn't exist or isn't available so
-            # we assert that the verses_html was not generated and
-            # thus not present in the document.
-            assert not verses_html
+        check_finished_document_without_verses_success(response)
 
 
-def test_es_419_ulb_col_es_419_tn_col_en_tq_col_es_419_tw_col_book_language_order() -> None:
+def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_2c_sl_hr_c() -> None:
+    """
+    Ask for an unavailable resource and assert that the verses_html is
+    not generated.
+    """
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "reg",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_1c() -> None:
+    """
+    Ask for an unavailable resource and assert that the verses_html is
+    not generated.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "reg",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_llx_reg_col_llx_tn_col_en_tq_col_llx_tw_col_book_language_order_1c_c() -> None:
+    """
+    Ask for an unavailable resource and assert that the verses_html is
+    not generated.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "reg",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "llx",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_es_419_ulb_col_es_419_tn_col_en_tq_col_es_419_tw_col_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "es-419",
@@ -1841,13 +7280,123 @@ def test_es_419_ulb_col_es_419_tn_col_en_tq_col_es_419_tw_col_book_language_orde
         check_finished_document_with_verses_success(response)
 
 
-def test_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order() -> None:
+def test_es_419_ulb_col_es_419_tn_col_en_tq_col_es_419_tw_col_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_es_419_ulb_col_es_419_tn_col_en_tq_col_es_419_tw_col_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_es_419_ulb_col_es_419_tn_col_en_tq_col_es_419_tw_col_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "es-419",
@@ -1875,13 +7424,123 @@ def test_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_orde
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_book_language_order() -> None:
+def test_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -1909,13 +7568,123 @@ def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_book_language_orde
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order() -> None:
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -1963,13 +7732,183 @@ def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order() -> None:
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_rom_en_tn_wa_rom_en_tq_wa_rom_en_tw_wa_rom_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -2017,14 +7956,184 @@ def test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_
         check_finished_document_with_verses_success(response)
 
 
-def test_invalid_document_request() -> None:
+def test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_2c_sl_hr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_jon_en_tn_wa_jon_en_tq_wa_jon_en_tw_wa_jon_es_419_ulb_rom_es_419_tn_rom_en_tq_rom_es_419_tw_rom_book_language_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "jon",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "rom",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "rom",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_invalid_document_request_1c() -> None:
     with pytest.raises(Exception):
         with TestClient(app=app, base_url=settings.api_test_url()) as client:
             response: requests.Response = client.post(
                 "/documents",
                 json={
                     "email_address": settings.TO_EMAIL_ADDRESS,
-                    "assembly_strategy_kind": "book_language_order",
+                    "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                    "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                    "layout_for_print": False,
                     "resource_requests": [
                         {
                             "lang_code": "",
@@ -2037,13 +8146,15 @@ def test_invalid_document_request() -> None:
             check_finished_document_with_verses_success(response)
 
 
-def test_wyy_reg_gen_wyy_reg_mic_book_language_order() -> None:
+def test_wyy_reg_gen_wyy_reg_mic_book_language_order_2c_sl_hr() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "wyy",
@@ -2061,7 +8172,59 @@ def test_wyy_reg_gen_wyy_reg_mic_book_language_order() -> None:
         check_finished_document_without_verses_success(response)
 
 
-def test_bdf_reg_mat_bdf_reg_mrk_pt_br_ulb_mat_pt_br_ulb_mrk_pt_br_tw_mat_pt_br_tw_mrk_pt_br_tq_mat_pt_br_tq_mrk_pt_br_tn_mat_pt_br_tn_mrk_fr_ulb_mat_fr_ulb_mrk_fr_tw_mat_fr_tw_mrk_fr_tq_mat_fr_tq_mrk_fr_tn_mat_fr_tn_mrk_fr_f10_mat_fr_f10_mrk_book_language_order() -> None:
+def test_wyy_reg_gen_wyy_reg_mic_book_language_order_2c_sl_hr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "wyy",
+                        "resource_type": "reg",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "wyy",
+                        "resource_type": "reg",
+                        "resource_code": "mic",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_wyy_reg_gen_wyy_reg_mic_book_language_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "wyy",
+                        "resource_type": "reg",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "wyy",
+                        "resource_type": "reg",
+                        "resource_code": "mic",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_bdf_reg_mat_bdf_reg_mrk_pt_br_ulb_mat_pt_br_ulb_mrk_pt_br_tw_mat_pt_br_tw_mrk_pt_br_tq_mat_pt_br_tq_mrk_pt_br_tn_mat_pt_br_tn_mrk_fr_ulb_mat_fr_ulb_mrk_fr_tw_mat_fr_tw_mrk_fr_tq_mat_fr_tq_mrk_fr_tn_mat_fr_tn_mrk_fr_f10_mat_fr_f10_mrk_book_language_order_2c_sl_hr() -> None:
     """
     Test case where document_request_key is too long and the system
     will use a timestamp for the document_request_key instead.
@@ -2071,7 +8234,249 @@ def test_bdf_reg_mat_bdf_reg_mrk_pt_br_ulb_mat_pt_br_ulb_mrk_pt_br_tw_mat_pt_br_
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "bdf",
+                        "resource_type": "reg",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "bdf",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {"lang_code": "fr", "resource_type": "ulb", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tw", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tq", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tn", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "f10", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "ulb", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tw", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tq", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tn", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "f10", "resource_code": "mrk"},
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_bdf_reg_mat_bdf_reg_mrk_pt_br_ulb_mat_pt_br_ulb_mrk_pt_br_tw_mat_pt_br_tw_mrk_pt_br_tq_mat_pt_br_tq_mrk_pt_br_tn_mat_pt_br_tn_mrk_fr_ulb_mat_fr_ulb_mrk_fr_tw_mat_fr_tw_mrk_fr_tq_mat_fr_tq_mrk_fr_tn_mat_fr_tn_mrk_fr_f10_mat_fr_f10_mrk_book_language_order_2c_sl_hr_c() -> None:
+    """
+    Test case where document_request_key is too long and the system
+    will use a timestamp for the document_request_key instead.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "bdf",
+                        "resource_type": "reg",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "bdf",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {"lang_code": "fr", "resource_type": "ulb", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tw", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tq", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tn", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "f10", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "ulb", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tw", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tq", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tn", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "f10", "resource_code": "mrk"},
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_bdf_reg_mat_bdf_reg_mrk_pt_br_ulb_mat_pt_br_ulb_mrk_pt_br_tw_mat_pt_br_tw_mrk_pt_br_tq_mat_pt_br_tq_mrk_pt_br_tn_mat_pt_br_tn_mrk_fr_ulb_mat_fr_ulb_mrk_fr_tw_mat_fr_tw_mrk_fr_tq_mat_fr_tq_mrk_fr_tn_mat_fr_tn_mrk_fr_f10_mat_fr_f10_mrk_book_language_order_1c() -> None:
+    """
+    Test case where document_request_key is too long and the system
+    will use a timestamp for the document_request_key instead.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "bdf",
+                        "resource_type": "reg",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "bdf",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "pt-br",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {"lang_code": "fr", "resource_type": "ulb", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tw", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tq", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "tn", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "f10", "resource_code": "mat"},
+                    {"lang_code": "fr", "resource_type": "ulb", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tw", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tq", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "tn", "resource_code": "mrk"},
+                    {"lang_code": "fr", "resource_type": "f10", "resource_code": "mrk"},
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_bdf_reg_mat_bdf_reg_mrk_pt_br_ulb_mat_pt_br_ulb_mrk_pt_br_tw_mat_pt_br_tw_mrk_pt_br_tq_mat_pt_br_tq_mrk_pt_br_tn_mat_pt_br_tn_mrk_fr_ulb_mat_fr_ulb_mrk_fr_tw_mat_fr_tw_mrk_fr_tq_mat_fr_tq_mrk_fr_tn_mat_fr_tn_mrk_fr_f10_mat_fr_f10_mrk_book_language_order_1c_c() -> None:
+    """
+    Test case where document_request_key is too long and the system
+    will use a timestamp for the document_request_key instead.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
                 "resource_requests": [
                     {
                         "lang_code": "bdf",
@@ -2152,12 +8557,134 @@ def test_aba_reg_tit_book_language_order() -> None:
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "book_language_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "aba",
                         "resource_type": "reg",
                         "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_for_print() -> None:
+    """
+    Test the case where we choose a layout for the user and they
+    select to format the result suitably for printing.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": None,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_fr_f10_col_fr_tn_col_fr_tq_col_fr_tw_col_book_language_order_layout_not_for_print() -> None:
+    """
+    Test the case where we choose a layout for the user and they
+    don't select to format the result suitably for printing.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER,
+                "assembly_layout_kind": None,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "col",
                     },
                 ],
             },

--- a/tests/e2e/test_api_assembly_strategy_combinations_lang_then_book.py
+++ b/tests/e2e/test_api_assembly_strategy_combinations_lang_then_book.py
@@ -8,6 +8,7 @@ import requests
 from fastapi.testclient import TestClient
 
 from document.config import settings
+from document.domain import model
 from document.entrypoints.app import app
 
 
@@ -70,14 +71,16 @@ def check_finished_document_without_verses_success(response: requests.Response) 
     assert response.ok
 
 
-def test_en_ulb_wa_tit_en_tn_wa_tit_language_book_order() -> None:
+def test_en_ulb_wa_tit_en_tn_wa_tit_language_book_order_2c_sl_hr() -> None:
     "English ulb-wa and tn-wa for book of Timothy."
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -95,13 +98,96 @@ def test_en_ulb_wa_tit_en_tn_wa_tit_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_sw_ulb_col_sw_tn_col_language_book_order() -> None:
+def test_en_ulb_wa_tit_en_tn_wa_tit_language_book_order_2c_sl_hr_c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_language_book_order_1c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_tit_en_tn_wa_tit_language_book_order_1c_c() -> None:
+    "English ulb-wa and tn-wa for book of Timothy."
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "sw",
@@ -119,13 +205,93 @@ def test_sw_ulb_col_sw_tn_col_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order() -> None:
+def test_sw_ulb_col_sw_tn_col_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "sw",
@@ -153,13 +319,123 @@ def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order() -> None:
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -197,13 +473,153 @@ def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_la
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_language_book_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_sw_ulb_col_sw_tn_col_sw_ulb_tit_sw_tn_tit_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -256,13 +672,198 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_language_book_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_sw_ulb_col_sw_tn_col_sw_tq_col_sw_ulb_tit_sw_tn_tit_sw_tq_tit_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -300,13 +901,153 @@ def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_la
         check_finished_document_with_verses_success(response)
 
 
-def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_tn_tit_sw_tq_tit_sw_tw_tit_language_book_order() -> None:
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tq_wa_col_sw_ulb_col_sw_tq_col_sw_ulb_tit_sw_tq_tit_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_tn_tit_sw_tq_tit_sw_tw_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -359,13 +1100,76 @@ def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw
         check_finished_document_without_verses_success(response)
 
 
-def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_language_book_order() -> None:
+def test_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_sw_tn_col_sw_tq_col_sw_tw_col_sw_tn_tit_sw_tq_tit_sw_tw_tit_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -403,13 +1207,61 @@ def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_langu
         check_finished_document_without_verses_success(response)
 
 
-def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_language_book_order() -> None:
+def test_en_tn_wa_col_en_tw_wa_col_sw_tn_col_sw_tw_col_sw_tn_tit_sw_tw_tit_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -437,13 +1289,51 @@ def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_langu
         check_finished_document_without_verses_success(response)
 
 
-def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_language_book_order() -> None:
+def test_en_tq_wa_col_en_tw_wa_col_sw_tq_col_sw_tw_col_sw_tq_tit_sw_tw_tit_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -461,13 +1351,15 @@ def test_en_tw_wa_col_sw_tw_col_sw_tw_tit_language_book_order() -> None:
         check_finished_document_without_verses_success(response)
 
 
-def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_language_book_order() -> None:
+def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_language_book_order_1c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -495,13 +1387,51 @@ def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_langu
         check_finished_document_without_verses_success(response)
 
 
-def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_language_book_order() -> None:
+def test_en_tn_wa_col_en_tq_wa_col_sw_tn_col_sw_tq_col_sw_tn_tit_sw_tq_tit_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -519,13 +1449,41 @@ def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_language_book_order() -> None:
         check_finished_document_without_verses_success(response)
 
 
-def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_language_book_order() -> None:
+def test_en_tq_wa_col_sw_tq_col_sw_tq_tit_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -548,13 +1506,46 @@ def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_language_book_order() -> None:
         check_finished_document_without_verses_success(response)
 
 
-def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_language_book_order() -> None:
+def test_en_tn_wa_col_sw_tn_col_sw_tn_tit_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "tn",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_without_verses_success(response)
+
+
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -577,13 +1568,108 @@ def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_language_book_order() -> None:
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_sw_ulb_col_sw_ulb_tit_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "sw",
+                        "resource_type": "ulb",
+                        "resource_code": "tit",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "gu",
@@ -616,13 +1702,138 @@ def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_language_book_order
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order() -> None:
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_ulb_mrk_gu_tn_mrk_gu_tq_mrk_gu_tw_mrk_gu_udb_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -655,13 +1866,138 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -689,13 +2025,123 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -723,13 +2169,123 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_language_book_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_tw_mrk_mr_udb_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tw",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -752,13 +2308,108 @@ def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order() -> None:
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tn_mrk_mr_udb_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tn",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "mr",
@@ -781,40 +2432,30 @@ def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-# TA resource type is not yet supported
-@pytest.mark.skip
-def test_gu_ulb_mic_gu_tn_mic_gu_tq_mic_gu_tw_mic_gu_ta_mic_language_book_order() -> None:
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
                 "resource_requests": [
                     {
-                        "lang_code": "gu",
+                        "lang_code": "mr",
                         "resource_type": "ulb",
-                        "resource_code": "mic",
+                        "resource_code": "mrk",
                     },
                     {
-                        "lang_code": "gu",
-                        "resource_type": "tn",
-                        "resource_code": "mic",
-                    },
-                    {
-                        "lang_code": "gu",
+                        "lang_code": "mr",
                         "resource_type": "tq",
-                        "resource_code": "mic",
+                        "resource_code": "mrk",
                     },
                     {
-                        "lang_code": "gu",
-                        "resource_type": "tw",
-                        "resource_code": "mic",
-                    },
-                    {
-                        "lang_code": "gu",
-                        "resource_type": "ta",
-                        "resource_code": "mic",
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
                     },
                 ],
             },
@@ -822,13 +2463,77 @@ def test_gu_ulb_mic_gu_tn_mic_gu_tq_mic_gu_tw_mic_gu_ta_mic_language_book_order(
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_ulb_gen_tl_udb_gen_language_book_order() -> None:
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_1c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_mr_ulb_mrk_mr_tq_mrk_mr_udb_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "ulb",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "tq",
+                        "resource_code": "mrk",
+                    },
+                    {
+                        "lang_code": "mr",
+                        "resource_type": "udb",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_ulb_gen_tl_udb_gen_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -846,13 +2551,41 @@ def test_tl_ulb_gen_tl_udb_gen_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_language_book_order() -> None:
+def test_tl_ulb_gen_tl_udb_gen_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "ulb",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "gu",
@@ -880,13 +2613,51 @@ def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_language_book_order() -> None:
+def test_gu_tn_mat_gu_tq_mat_gu_tw_mat_gu_udb_mat_language_book_order_1c_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tw",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "gu",
@@ -909,13 +2680,108 @@ def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_language_book_order() -> None:
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_gu_tn_mat_gu_tq_mat_gu_udb_mat_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tn",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "tq",
+                        "resource_code": "mat",
+                    },
+                    {
+                        "lang_code": "gu",
+                        "resource_type": "udb",
+                        "resource_code": "mat",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -938,13 +2804,108 @@ def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_tq_gen_tl_udb_gen_language_book_order() -> None:
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tn_gen_tl_tw_gen_tl_udb_gen_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tn",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tq_gen_tl_udb_gen_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -962,13 +2923,93 @@ def test_tl_tq_gen_tl_udb_gen_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_tw_gen_tl_udb_gen_language_book_order() -> None:
+def test_tl_tq_gen_tl_udb_gen_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tq_gen_tl_udb_gen_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tq_gen_tl_udb_gen_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tq",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tw_gen_tl_udb_gen_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -986,13 +3027,93 @@ def test_tl_tw_gen_tl_udb_gen_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_tl_udb_gen_language_book_order() -> None:
+def test_tl_tw_gen_tl_udb_gen_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tw_gen_tl_udb_gen_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_tw_gen_tl_udb_gen_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "tw",
+                        "resource_code": "gen",
+                    },
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_tl_udb_gen_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "tl",
@@ -1005,14 +3126,37 @@ def test_tl_udb_gen_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_language_book_order() -> None:
+def test_tl_udb_gen_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "tl",
+                        "resource_type": "udb",
+                        "resource_code": "gen",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_language_book_order_2c_sl_hr() -> None:
     """Demonstrate listing unfound resources, in this case fr-udb-rev"""
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1045,7 +3189,133 @@ def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_language_book_order
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order() -> None:
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_language_book_order_2c_sl_hr_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "udb",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_language_book_order_1c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "udb",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_udb_rev_language_book_order_1c_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "udb",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_2c_sl_hr() -> None:
     """
     Demonstrate two USFM resources, French, and use of a special
     USFM resource: f10.
@@ -1055,7 +3325,9 @@ def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1088,7 +3360,7 @@ def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order() -> None:
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_2c_sl_hr_c() -> None:
     """
     Demonstrate two USFM resources, French, and use of a special
     USFM resource: f10.
@@ -1098,7 +3370,144 @@ def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order() -> None
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_1c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tn_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_1c_c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tn",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_2c_sl_hr() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1126,14 +3535,136 @@ def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order() -> None
         check_finished_document_with_verses_success(response)
 
 
-def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_language_book_order() -> None:
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_2c_sl_hr_c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_1c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tq_rev_fr_tw_rev_fr_f10_rev_language_book_order_1c_c() -> None:
+    """
+    Demonstrate two USFM resources, French, and use of a special
+    USFM resource: f10.
+    """
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tq",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_language_book_order_2c_sl_hr() -> None:
     """Demonstrate listing unfound resources, in this case fr-udb-rev"""
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "fr",
@@ -1156,13 +3687,111 @@ def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_language_book_order() -> None:
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_language_book_order_2c_sl_hr_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_language_book_order_1c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_fr_ulb_rev_fr_tw_rev_fr_udb_rev_language_book_order_1c_c() -> None:
+    """Demonstrate listing unfound resources, in this case fr-udb-rev"""
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "ulb",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "tw",
+                        "resource_code": "rev",
+                    },
+                    {
+                        "lang_code": "fr",
+                        "resource_type": "f10",
+                        "resource_code": "rev",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "en",
@@ -1210,13 +3839,183 @@ def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_
         check_finished_document_with_verses_success(response)
 
 
-def test_kbt_reg_2co_ajg_reg_2co_pmm_reg_mrk_language_book_order() -> None:
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_en_ulb_wa_col_en_tn_wa_col_en_tq_wa_col_en_tw_wa_col_es_419_ulb_col_es_419_tn_col_es_419_tq_col_es_419_tw_col_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "en",
+                        "resource_type": "ulb-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tn-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tq-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "en",
+                        "resource_type": "tw-wa",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "ulb",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tn",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tq",
+                        "resource_code": "col",
+                    },
+                    {
+                        "lang_code": "es-419",
+                        "resource_type": "tw",
+                        "resource_code": "col",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_reg_2co_pmm_reg_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "kbt",
@@ -1239,13 +4038,201 @@ def test_kbt_reg_2co_ajg_reg_2co_pmm_reg_mrk_language_book_order() -> None:
         check_finished_document_with_verses_success(response)
 
 
-def test_kbt_reg_2co_ajg_x_adjtalagbe_reg_2co_pmm_reg_mrk_language_book_order() -> None:
+def test_kbt_reg_2co_ajg_reg_2co_pmm_reg_mrk_language_book_order_2c_sl_hr_c() -> None:
     with TestClient(app=app, base_url=settings.api_test_url()) as client:
         response: requests.Response = client.post(
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "kbt",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "ajg",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "pmm",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_reg_2co_pmm_reg_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "kbt",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "ajg",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "pmm",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_reg_2co_pmm_reg_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "kbt",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "ajg",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "pmm",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_x_adjtalagbe_reg_2co_pmm_reg_mrk_language_book_order_2c_sl_hr() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "kbt",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "ajg-x-adjtalagbe",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "pmm",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_x_adjtalagbe_reg_2co_pmm_reg_mrk_language_book_order_2c_sl_hr_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT_COMPACT,
+                "layout_for_print": True,
+                "resource_requests": [
+                    {
+                        "lang_code": "kbt",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "ajg-x-adjtalagbe",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "pmm",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_x_adjtalagbe_reg_2co_pmm_reg_mrk_language_book_order_1c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN,
+                "layout_for_print": False,
+                "resource_requests": [
+                    {
+                        "lang_code": "kbt",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "ajg-x-adjtalagbe",
+                        "resource_type": "reg",
+                        "resource_code": "2co",
+                    },
+                    {
+                        "lang_code": "pmm",
+                        "resource_type": "reg",
+                        "resource_code": "mrk",
+                    },
+                ],
+            },
+        )
+        check_finished_document_with_verses_success(response)
+
+
+def test_kbt_reg_2co_ajg_x_adjtalagbe_reg_2co_pmm_reg_mrk_language_book_order_1c_c() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response: requests.Response = client.post(
+            "/documents",
+            json={
+                "email_address": settings.TO_EMAIL_ADDRESS,
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.ONE_COLUMN_COMPACT,
+                "layout_for_print": True,
                 "resource_requests": [
                     {
                         "lang_code": "kbt",

--- a/tests/e2e/test_send_email.py
+++ b/tests/e2e/test_send_email.py
@@ -6,6 +6,7 @@ import yaml
 from fastapi.testclient import TestClient
 
 from document.config import settings
+from document.domain import model
 from document.entrypoints.app import app
 
 logger = settings.logger(__name__)
@@ -23,7 +24,9 @@ def test_send_email_with_ar_nav_jud_pdf() -> None:
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "ar",

--- a/tests/e2e/test_stream_pdf.py
+++ b/tests/e2e/test_stream_pdf.py
@@ -6,6 +6,7 @@ import yaml
 from fastapi.testclient import TestClient
 
 from document.config import settings
+from document.domain import model
 from document.entrypoints.app import app
 
 logger = settings.logger(__name__)
@@ -23,7 +24,9 @@ def test_stream_ar_nav_jud_pdf() -> None:
             "/documents",
             json={
                 "email_address": settings.TO_EMAIL_ADDRESS,
-                "assembly_strategy_kind": "language_book_order",
+                "assembly_strategy_kind": model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER,
+                "assembly_layout_kind": model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT,
+                "layout_for_print": False,
                 "resource_requests": [
                     {
                         "lang_code": "ar",

--- a/tests/unit/test_document_generator.py
+++ b/tests/unit/test_document_generator.py
@@ -8,6 +8,9 @@ def test_coalesce_english_tn_requests() -> None:
     assembly_strategy_kind: model.AssemblyStrategyEnum = (
         model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER
     )
+    assembly_layout_kind: model.AssemblyLayoutEnum = (
+        model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT
+    )
     resource_requests: list[model.ResourceRequest] = []
     resource_requests.append(
         model.ResourceRequest(
@@ -33,6 +36,8 @@ def test_coalesce_english_tn_requests() -> None:
     document_request = model.DocumentRequest(
         email_address=settings.FROM_EMAIL_ADDRESS,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=False,
         resource_requests=resource_requests,
     )
     assert len(document_request.resource_requests) == 5
@@ -121,7 +126,10 @@ def test_document_request_key_too_long_for_semantic_result() -> None:
         for component in components
     ]
     assembly_strategy_kind = model.AssemblyStrategyEnum.BOOK_LANGUAGE_ORDER
+    assembly_layout_kind = (
+        model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT
+    )
     key = document_generator.document_request_key(
-        resource_requests, assembly_strategy_kind
+        resource_requests, assembly_strategy_kind, assembly_layout_kind
     )
     assert re.search(r"[0-9]+_[0-9]+", key)

--- a/tests/unit/test_resource_lookup_api.py
+++ b/tests/unit/test_resource_lookup_api.py
@@ -8,6 +8,9 @@ def test_lookup_successes() -> None:
     assembly_strategy_kind: model.AssemblyStrategyEnum = (
         model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER
     )
+    assembly_layout_kind: model.AssemblyLayoutEnum = (
+        model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT
+    )
     resource_requests: list[model.ResourceRequest] = []
     resource_requests.append(
         model.ResourceRequest(
@@ -30,6 +33,8 @@ def test_lookup_successes() -> None:
     document_request = model.DocumentRequest(
         email_address=settings.FROM_EMAIL_ADDRESS,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=True,
         resource_requests=resource_requests,
     )
     for resource_request in document_request.resource_requests:
@@ -57,6 +62,9 @@ def test_lookup_failures() -> None:
     assembly_strategy_kind: model.AssemblyStrategyEnum = (
         model.AssemblyStrategyEnum.LANGUAGE_BOOK_ORDER
     )
+    assembly_layout_kind: model.AssemblyLayoutEnum = (
+        model.AssemblyLayoutEnum.TWO_COLUMN_SCRIPTURE_LEFT_HELPS_RIGHT
+    )
     resource_requests: list[model.ResourceRequest] = []
     resource_requests.append(
         model.ResourceRequest(lang_code="zh", resource_type="ulb", resource_code="jol")
@@ -64,6 +72,8 @@ def test_lookup_failures() -> None:
     document_request = model.DocumentRequest(
         email_address=settings.FROM_EMAIL_ADDRESS,
         assembly_strategy_kind=assembly_strategy_kind,
+        assembly_layout_kind=assembly_layout_kind,
+        layout_for_print=False,
         resource_requests=resource_requests,
     )
 


### PR DESCRIPTION
* Implements the following requirements:
  - Let user choose if they are intending to print final result and then
    have system intelligently choose the appropriate layout given their choice
    of assembly strategy, layout for print, and document request contents.
  - Provide several new layouts.
  - Add a couple hundred more e2e tests to cover the combinatorics of
    assembly strategy, assembly layout, and resource requests.
  - Layouts are implemented in two facets: structurally and
    stylistically via CSS. The structural aspects are implemented at the
    intersection of the document_generator, assembly_strategies, parsing,
    link_print_transformer_preprocessor, and link_transformer_preprocessor
    modules.

* Additional updates:
  - Serve HTML result as well as PDF to the user.
  - Improvement in text labels in the UI so that messaging is free of
    project terminology and more universally understandable.
  - Update Docker image for Node
  - Limit UI to allow user to select two languages rather than three. The
    reason for this is two-fold: 1) It is likely that the user only ever
    actually wants at most two languages. 2) Supporting a two language
    choice rather than three makes it more easily possible to support the
    new two column scripture left, scripture right layout. This can be changed
    and still retain the two column scripture left, scripture right layout. I
    just want to test this out as a user experience to get feedback.
  - Note that the API for forming document requests has changed
    slightly. See tests in
    tests/e2e/test_api_assembly_strategy_combinations_book_then_lang.py and
    tests/e2e/test_api_assembly_strategy_combinations_lang_then_book.py
    for examples.
- Add English bible commentary feature (version 1 subject to review for changes)