### PR TITLE
Add CORS origin for develop side testing

### DIFF
--- a/.env
+++ b/.env
@@ -53,14 +53,19 @@ ENABLE_ASSET_CACHING=true
 # files on disk are considered fresh rather than reacqiring them. In hours.
 ASSET_CACHING_PERIOD=168
 
-#  * http://localhost:3000 covers requests originating from the case
-#  where 'npm run dev' is invoked to run vite outside Docker. This
-#  results in vite's development mode which runs on port 3000.
-#  * http://localhost:8001 covers requests originating from the case
-#  where 'npm run build' is invoked which executes a vite build. Docker
-#  then copies built assets to nginx environment which then serves them
-#  on port 80 which is then mapped to port 8001 in docker-compose.yml.
-BACKEND_CORS_ORIGINS='["http://localhost:3000", "http://localhost:8001", "http://dev.local:3000"]'
+# * http://localhost:3000 covers requests originating from the case
+# where 'npm run dev' is invoked to run vite (to run svelte js frontend)
+# outside Docker. This results in vite's development mode which runs on
+# port 3000.
+# * http://localhost:8001 covers requests originating from the case
+# where 'npm run build' is invoked which executes a vite build. Docker
+# then copies built assets to nginx environment which then serves them
+# on port 80 which is then mapped to port 8001 in docker-compose.yml.
+# * http:localhost:4173 covers requests originating from the case where
+# 'npm run preview' is invoked which executes serving the built for
+# production (via 'npm build') frontend locally in a
+# non-production-grade web server.
+BACKEND_CORS_ORIGINS='["http://localhost:3000", "http://localhost:8001", "http://dev.local:3000", "http://localhost:4173"]'
 
 # local image tag for local dev with prod image
 IMAGE_TAG=local


### PR DESCRIPTION
Svelte production style build can be tested in local development
environment on a special port on localhost. Useful to smoke test build
artifacts before going to production.

This has no impact on anything production side or on deployment, it is strictly a develop side feature.