### PR TITLE
Simplify code to remove named markdown section

### DIFF
--- a/backend/document/config.py
+++ b/backend/document/config.py
@@ -270,6 +270,8 @@ class Settings(BaseSettings):
     MARKDOWN_SECTIONS_TO_REMOVE: list[str] = [
         "Examples from the Bible stories",
         "Links",
+        "Picture of",
+        "Pictures",
     ]
 
     #  Return the from email to use for sending email with generated PDF

--- a/backend/document/domain/parsing.py
+++ b/backend/document/domain/parsing.py
@@ -783,6 +783,7 @@ def markdown_instance(
     resource_requests: Sequence[model.ResourceRequest],
     layout_for_print: bool,
     tw_resource_dir: Optional[str] = None,
+    sections_to_remove: list[str] = settings.MARKDOWN_SECTIONS_TO_REMOVE,
 ) -> markdown.Markdown:
     """
     Initialize and return a markdown.Markdown instance that can be
@@ -796,7 +797,12 @@ def markdown_instance(
     if not layout_for_print:  # User doesn't want to print result
         return markdown.Markdown(
             extensions=[
-                remove_section_preprocessor.RemoveSectionExtension(),
+                remove_section_preprocessor.RemoveSectionExtension(
+                    sections_to_remove=[
+                        sections_to_remove,
+                        "Markdown sections to remove",
+                    ]
+                ),
                 link_transformer_preprocessor.LinkTransformerExtension(
                     lang_code=[lang_code, "Language code for resource"],
                     resource_requests=[
@@ -814,7 +820,9 @@ def markdown_instance(
     # things since we are printing.
     return markdown.Markdown(
         extensions=[
-            remove_section_preprocessor.RemoveSectionExtension(),
+            remove_section_preprocessor.RemoveSectionExtension(
+                sections_to_remove=[sections_to_remove, "Markdown sections to remove"]
+            ),
             link_print_transformer_preprocessor.LinkPrintTransformerExtension(
                 lang_code=[lang_code, "Language code for resource"],
                 resource_requests=[

--- a/backend/document/markdown_extensions/remove_section_preprocessor.py
+++ b/backend/document/markdown_extensions/remove_section_preprocessor.py
@@ -27,28 +27,17 @@ class RemoveSectionPreprocessor(Preprocessor):
             md = self.remove_md_section(md, section)
         return md.split("\n")
 
-    def remove_md_section(self, md: str, section_name: str) -> str:
-        """
-        Given markdown and a section name, removes the section header and the
-        text contained in the section.
-        """
-        header_regex = re.compile("^#.*$")
-        section_regex = re.compile("^#+ {}".format(section_name))
-        out_md = ""
-        in_section = False
-        for line in md.splitlines():
-            if in_section:
-                if header_regex.match(line):
-                    # We found a header.  The section is over.
-                    out_md += line + "\n"
-                    in_section = False
-            else:
-                if section_regex.match(line):
-                    # We found the section header.
-                    in_section = True
-                else:
-                    out_md = "{}{}\n".format(out_md, line)
-        return out_md
+    def remove_md_section(
+        self,
+        md: str,
+        section_name: str,
+        # See https://regex101.com/r/SSItAG/1
+        section_regex_fmt_str: str = r"\#+ +{}.*$\n*.*",
+    ) -> str:
+        md_out = re.sub(
+            section_regex_fmt_str.format(section_name), "", md, 0, re.DOTALL
+        )
+        return md_out
 
     def run(self, lines: list[str]) -> list[str]:
         """Entrypoint."""

--- a/backend/document/markdown_extensions/remove_section_preprocessor.py
+++ b/backend/document/markdown_extensions/remove_section_preprocessor.py
@@ -14,30 +14,43 @@ logger = settings.logger(__name__)
 class RemoveSectionPreprocessor(Preprocessor):
     """Remove arbitrary Markdown sections."""
 
-    def __init__(self, config: dict[str, list[str]], md: markdown.Markdown) -> None:
-        """Initialize."""
-        # Example use of config. See __init__ for RemoveSectionExtension
-        # below for initialization.
-        # self.encoding = config.get("encoding")
+    def __init__(self, md: markdown.Markdown, sections_to_remove: list[str]) -> None:
+        self._md: markdown.Markdown = md
+        self._sections_to_remove: list[str] = sections_to_remove
+        logger.debug("sections_to_remove: %s", sections_to_remove)
         super().__init__()
 
-    def remove_sections(self, md: str) -> list[str]:
+    def remove_sections(
+        self,
+        md: str,
+    ) -> list[str]:
         """Remove various markdown sections."""
-        for section in settings.MARKDOWN_SECTIONS_TO_REMOVE:
+        for section in self._sections_to_remove:
             md = self.remove_md_section(md, section)
         return md.split("\n")
 
-    def remove_md_section(
-        self,
-        md: str,
-        section_name: str,
-        # See https://regex101.com/r/SSItAG/1
-        section_regex_fmt_str: str = r"\#+ +{}.*$\n*.*",
-    ) -> str:
-        md_out = re.sub(
-            section_regex_fmt_str.format(section_name), "", md, 0, re.DOTALL
-        )
-        return md_out
+    def remove_md_section(self, md: str, section_name: str) -> str:
+        """
+        Given markdown and a section name, removes the section header and the
+        text contained in the section.
+        """
+        header_regex = re.compile("^#.*$")
+        section_regex = re.compile("^#+ {}".format(section_name))
+        out_md = ""
+        in_section = False
+        for line in md.splitlines():
+            if in_section:
+                if header_regex.match(line):
+                    # We found a header.  The section is over.
+                    out_md += line + "\n"
+                    in_section = False
+            else:
+                if section_regex.match(line):
+                    # We found the section header.
+                    in_section = True
+                else:
+                    out_md = "{}{}\n".format(out_md, line)
+        return out_md
 
     def run(self, lines: list[str]) -> list[str]:
         """Entrypoint."""
@@ -50,24 +63,16 @@ class RemoveSectionExtension(Extension):
     """Wikilink to Markdown link conversion extension."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize."""
-        self.md: markdown.Markdown
-        self.config = {
-            # Example config entry from the snippets extension that
-            # ships with Python-Markdown library.
-            # "encoding": ["utf-8", 'Encoding of snippets - Default: "utf-8"'],
-        }
-        super().__init__(*args, **kwargs)
+        """Entrypoint."""
+        self.config = kwargs
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:
-        """Register the extension."""
+        """Automatically called by superclass."""
         self.md = md
         md.registerExtension(self)
-        config = self.getConfigs()
-        removesection = RemoveSectionPreprocessor(config, md)
-        md.preprocessors.register(removesection, "remove_section", 32)
-
-
-def makeExtension(*args: Any, **kwargs: Any) -> RemoveSectionExtension:
-    """Return extension."""
-    return RemoveSectionExtension(*args, **kwargs)
+        remove_section_transformer = RemoveSectionPreprocessor(
+            md, self.getConfig("sections_to_remove")
+        )
+        md.preprocessors.register(
+            remove_section_transformer, "remove_section_transformer", 32
+        )

--- a/tests/unit/test_markdown_extensions.py
+++ b/tests/unit/test_markdown_extensions.py
@@ -29,23 +29,58 @@ def test_remove_section_preprocessor() -> None:
     """
     Test the remove section Markdown pre-processor extension.
     """
-    source = """# apostle
+    source = """# blah
 
-## Related Ideas:
+## Flub:
 
-apostleship
+Nullam eu ante vel est convallis dignissim.  Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio.  Nunc porta vulputate tellus.  Nunc rutrum turpis sed pede.  Sed bibendum.  Aliquam posuere.  Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.  Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna.  Curabitur vulputate vestibulum lorem.  Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.  Sed id ligula quis est convallis tempor.  Curabitur lacinia pulvinar nibh.  Nam a sapien.
+
+
+## Picture of blah:
+
+<a href="http://example.com"><img src="http://example.com/foo.png" ></a>
 
 ## Links:
 
-The "apostles" were men sent by Jesus to preach about God and his kingdom. The term "apostleship" refers to the position and authority of those who were chosen as apostles.
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
 
-* The word "apostle" means "someone who is sent out for a special purpose." The apostle has the same authority as the one who sent him.
-* Jesus' twelve closest disciples became the first apostles. Other men, such as Paul and James, also became apostles.
-* By God's power, the apostles were able to boldly preach the gospel and heal people, and were able to force demons to come out of people."""
-    expected = """<h1>apostle</h1>\n<h2>Related Ideas:</h2>\n<p>apostleship</p>"""
+
+## Delete me:
+
+* foo
+* bar
+
+## Keep me:
+
+* Blatz
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."""
+
+    source_expected = """# blah
+
+## Flub:
+
+Nullam eu ante vel est convallis dignissim.  Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio.  Nunc porta vulputate tellus.  Nunc rutrum turpis sed pede.  Sed bibendum.  Aliquam posuere.  Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.  Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna.  Curabitur vulputate vestibulum lorem.  Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.  Sed id ligula quis est convallis tempor.  Curabitur lacinia pulvinar nibh.  Nam a sapien.
+
+
+## Keep me:
+
+* Blatz
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."""
+
+    md_source = markdown.Markdown()
+    expected = md_source.convert(source_expected)
 
     md = markdown.Markdown(
-        extensions=[remove_section_preprocessor.RemoveSectionExtension()]
+        extensions=[
+            remove_section_preprocessor.RemoveSectionExtension(
+                sections_to_remove=[
+                    ["Picture", "Links", "Delete me"],
+                    "Sections to remove",
+                ]
+            )
+        ]
     )
     actual = md.convert(source)
     assert expected == actual


### PR DESCRIPTION
Legacy method that removed specified markdown sections was highly
imperative and exhibits the boolean flag anti-pattern. Replaced with
simple declarative regex expression.