### PR TITLE
Get black python code formatter from git

### DIFF
--- a/backend/requirements-dev.in
+++ b/backend/requirements-dev.in
@@ -1,5 +1,5 @@
 -c requirements.txt
-black
+git+https://github.com/psf/black
 cohesion
 dlint
 flake8


### PR DESCRIPTION
Doing so makes it possible to avoid a python package dependency
resolution conflict while also using the latest version of black.