### PR TITLE
Add VITE_BACKEND_URL env var to .env file

### DIFF
--- a/.env
+++ b/.env
@@ -67,5 +67,12 @@ ASSET_CACHING_PERIOD=168
 # non-production-grade web server.
 BACKEND_CORS_ORIGINS='["http://localhost:3000", "http://localhost:8001", "http://dev.local:3000", "http://localhost:4173"]'
 
+# Also available from frontend/.env and frontend/.env.production to
+# Svelte frontend, but not available to docker-compose except from
+# this .env file which is implicitly read by docker-compose.
+# See https://vsupalov.com/docker-arg-env-variable-guide/
+# for details regarding docker arg, env, env_file, .env, etc..
+VITE_BACKEND_API_URL="http://localhost:5005"
+
 # local image tag for local dev with prod image
 IMAGE_TAG=local


### PR DESCRIPTION
In production the value of this env var is provided in the
environment. Instead of having to provide it on the command line in
development let's provide it in the .env file. This has no impact on production 
due to Docker's precedence rules for satisfying environment variable values.