### PR TITLE
Remove env_file stanza in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: "3"
 services:
   api:
     image: wycliffeassociates/doc:${IMAGE_TAG}
-    env_file:
-      - .env
     environment:
       FROM_EMAIL_ADDRESS: ${FROM_EMAIL_ADDRESS}
       SMTP_PASSWORD: ${SMTP_PASSWORD}


### PR DESCRIPTION
Docker compose implicitly looks for a dotenv filed named .env in the
directory where docker-compose was invoked. Therefore there is no need
to reference an env_file so named and located. I didn't know that when
I originally created the docker-compose.yml file.