### PR TITLE
Add option to clone git repos via GitPython package

### DIFF
--- a/backend/document/config.py
+++ b/backend/document/config.py
@@ -142,6 +142,8 @@ class Settings(BaseSettings):
     # Indicate whether running in Docker container.
     IN_CONTAINER: bool = False
 
+    USE_GIT_CLI: bool = False
+
     def working_dir(self) -> str:
         """
         The directory where the resources will be placed once

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -3,6 +3,7 @@ PyYAML
 aiofiles
 bs4
 fastapi
+GitPython
 git+https://github.com/linearcombination/USFM-Tools.git@develop#egg=USFM-Tools
 gunicorn
 jinja2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,10 @@ fastapi==0.75.0
     # via -r ./backend/requirements.in
 future==0.18.2
     # via usfm-tools
+gitdb==4.0.9
+    # via gitpython
+gitpython==3.1.27
+    # via -r ./backend/requirements.in
 gunicorn==20.1.0
     # via -r ./backend/requirements.in
 h11==0.13.0
@@ -103,6 +107,8 @@ requests==2.27.1
     # via -r ./backend/requirements.in
 six==1.16.0
     # via jsonpath-rw
+smmap==5.0.0
+    # via gitdb
 sniffio==1.2.0
     # via anyio
 soupsieve==2.3.1


### PR DESCRIPTION
Python linting tools always flag use of cli via subprocess in favor of
using a python package for same due to security implications.
GitPython package works well for this purpose. Kept ability to use git
cli too in case we see any long term flakiness with GitPython. All e2e
tests pass using either now.