### PR TITLE
Change labels for result format checkboxes

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -13,11 +13,11 @@ VITE_WAIT_MSG="Thank you for submitting your document request. Please wait while
 VITE_ERROR_MSG="There was a problem handling your document request. The issue has been logged and we will take a look at it. We apologize for the inconvenience. Please try another selection by resetting the form and trying your new selection."
 
 VITE_TOP_H2_HEADER="Document Request"
-VITE_EMAIL_LABEL="Email (Optional)"
-VITE_LAYOUT_FOR_PRINT_LABEL="Do you want to format the result for printing (less whitespace)?"
-VITE_PDF_LABEL="Do you want to generate a PDF result?"
-VITE_EPUB_LABEL="Do you want to generate an ePub result?"
-VITE_DOCX_LABEL="Do you want to generate a Docx result?"
+VITE_EMAIL_LABEL="(Optional) Email"
+VITE_LAYOUT_FOR_PRINT_LABEL="Format for Printing (fewer pages)"
+VITE_PDF_LABEL="(Optional) Generate PDF"
+VITE_EPUB_LABEL="(Optional) Generate ePub"
+VITE_DOCX_LABEL="(Optional) Generate Docx"
 # VITE_ASSEMBLY_STRATEGY_HEADER="Please select the assembly strategy for this document"
 VITE_ASSEMBLY_STRATEGY_HEADER="How do you want to group content?"
 


### PR DESCRIPTION
To be more succinct and indicate which fields are optional. That
fields be marked as optional was requested by content team. HTML is
always generated, but other output formats are truly optional.