### PR TITLE
Set defaults to not break userspace

### DIFF
--- a/backend/document/domain/model.py
+++ b/backend/document/domain/model.py
@@ -163,7 +163,7 @@ class DocumentRequest(BaseModel):
     layout_for_print: bool = False
     resource_requests: Sequence[ResourceRequest]
     # Indicate whether PDF should be generated.
-    generate_pdf: bool = False
+    generate_pdf: bool = True
     # Indicate whether ePub should be generated.
     generate_epub: bool = False
     # Indicate whether Docx should be generated.

--- a/backend/document/domain/model.py
+++ b/backend/document/domain/model.py
@@ -160,14 +160,14 @@ class DocumentRequest(BaseModel):
     # document request. This happens in
     # document_generator.select_assembly_layout_kind if
     # assembly_layout_kind is None in the document request.
-    layout_for_print: bool
+    layout_for_print: bool = False
     resource_requests: Sequence[ResourceRequest]
     # Indicate whether PDF should be generated.
-    generate_pdf: bool
+    generate_pdf: bool = False
     # Indicate whether ePub should be generated.
-    generate_epub: bool
+    generate_epub: bool = False
     # Indicate whether Docx should be generated.
-    generate_docx: bool
+    generate_docx: bool = False
 
 
 @final


### PR DESCRIPTION
Not sure if this is the right way to set defaults, but we should set them so we don't break the API for other API users.