### PR TITLE
Add ability to profile tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,9 @@ local-smoke-test-with-translation-words29: local-prepare-for-tests
 	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pytest tests/e2e/ -k test_en_ulb_wa_mat_language_book_order_1c
 
 
+.PHONY: local-smoke-test-with-translation-words29-profile
+local-smoke-test-with-translation-words29-profile: local-prepare-for-tests
+	IN_CONTAINER=false ENABLE_ASSET_CACHING=true SEND_EMAIL=false FROM_EMAIL="foo@example.com" TO_EMAIL="foo@example.com" pyinstrument -m pytest tests/e2e/ -k test_es_419_ulb_col_es_419_ulb_eph_es_419_tn_col_es_419_tq_col_es_419_tw_col_es_419_tw_eph_book_language_order
 
 # This is one to run after running local-e2e-tests or any tests which
 # has yielded HTML and PDFs that need to be checked for linking

--- a/backend/requirements-dev.in
+++ b/backend/requirements-dev.in
@@ -15,6 +15,7 @@ isort
 mypy
 pre-commit
 pygount
+pyinstrument
 pylint
 pyls-mypy
 pytest

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -167,6 +167,8 @@ pygments==2.12.0
     #   rich
 pygount==1.4.0
     # via -r ./backend/requirements-dev.in
+pyinstrument==4.3.0
+    # via -r ./backend/requirements-dev.in
 pylint==2.14.1
     # via -r ./backend/requirements-dev.in
 pyls-mypy==0.1.8


### PR DESCRIPTION
See if there are any bottlenecks.

This does not impact v2_ui_plus tagged code in develop, i.e., does not have to be in the deploy happening today. This just adds a makefile target that allows the developer to see where time is spent on an end to end web request via pytest tests using pyinstrument package. The results were good for our code. There is some inherit network latency being web centric, but overall pretty good. mypyc helps too.