### PR TITLE
Reduce vertical space after TN notes headers

### DIFF
--- a/backend/templates/html/header_enclosing.html
+++ b/backend/templates/html/header_enclosing.html
@@ -46,8 +46,14 @@
       }
 
       h5 {
-        padding-bottom: 0em;
-        margin-bottom: 0em;
+        padding-bottom: 0;
+        margin-bottom: 0;
+      }
+
+      /* Decrease vertical space between paragraph that follows h5 */
+      h5 + p {
+        margin-top: 0;
+        padding-top: 0;
       }
 
       .chunk-break {


### PR DESCRIPTION
By request, remove vertical space between h5 header and p elements so that PDF output is similar to Docx output for paper saving printing purposes.