### PR TITLE
Limit TW words

### DIFF
--- a/.env
+++ b/.env
@@ -35,6 +35,9 @@ SMTP_PORT=587
 PORT=5005
 # Control caching of resource assets to save on network traffic
 ASSET_CACHING_ENABLED=true
+# Limit the translation words, TW, to only those words which appear in
+# the language and book combination requested
+LIMIT_WORDS=true
 # Caching window of time in which cloned or downloaded resource asset
 # files on disk are considered fresh rather than reacqiring them. In hours.
 ASSET_CACHING_PERIOD=168

--- a/.env
+++ b/.env
@@ -9,12 +9,8 @@
 # foo=This is ok without quotes
 # bar="This wouldn't be ok without quotes"
 
-# Used in Dockerfile to get wkhtmltox
-WKHTMLTOX_LOC=https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb
-
 # Location where the api finds translations.json
 TRANSLATIONS_JSON_LOCATION=http://bibleineverylanguage.org/wp-content/themes/bb-theme-child/data/translations.json
-LOGGING_CONFIG=src/document/logging_config.yaml
 
 # Container facing port for Uvicorn Python server.
 API_LOCAL_PORT=5005
@@ -23,8 +19,6 @@ API_LOCAL_PORT=5005
 # generation of PDF.
 SUCCESS_MESSAGE="Success! Please retrieve your generated document using a GET REST request to /pdf/{document_request_key}, /epub/{document_request_key}, or /docx/{document_request_key} (depending on whether you requested PDF, ePub, or Docx result) where document_request_key is the finished_document_request_key in this payload."
 
-# Return the message to show to user on failure generating PDF.
-FAILURE_MESSAGE="The document request could not be fulfilled either because the resources requested are not available either currently or at all or because the system does not yet support the resources requested."
 
 # Sending emails if off by default due to automated testing, turn it
 # on for production use
@@ -37,18 +31,10 @@ EMAIL_SEND_SUBJECT=The BIEL PDF you requested is attached
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 
-# We are running in the container. This is used by the system to
-# determine the location of the working and output directories.
-IN_CONTAINER=true
 # The port to pass to gunicorn via ./backend/gunicorn.conf.py
 PORT=5005
-# If true, run pytest test suite during docker build of backend container to verify correctness and
-# to generate assets which preheat cache. Note that it takes about 30
-# minutes for the test suite to conclude, hence it is set to false by
-# default.
-RUN_TESTS=false
 # Control caching of resource assets to save on network traffic
-ENABLE_ASSET_CACHING=true
+ASSET_CACHING_ENABLED=true
 # Caching window of time in which cloned or downloaded resource asset
 # files on disk are considered fresh rather than reacqiring them. In hours.
 ASSET_CACHING_PERIOD=168

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,14 @@ build-no-pip-update-run-tests: checkvenv down clean-mypyc-artifacts
 .PHONY: build-no-cache
 build-no-cache: checkvenv down clean-mypyc-artifacts local-install-deps-prod
 	export IMAGE_TAG=local && \
-	docker build --progress=plain --no-cache -t wycliffeassociates/doc:$${IMAGE_TAG} . && \
-	docker build --progress=plain --no-cache -t wycliffeassociates/doc-ui:$${IMAGE_TAG} ./frontend
+	docker build --progress=plain --no-cache --pull -t wycliffeassociates/doc:$${IMAGE_TAG} . && \
+	docker build --progress=plain --no-cache --pull -t wycliffeassociates/doc-ui:$${IMAGE_TAG} ./frontend
 
 .PHONY: build-no-cache-no-pip-update
 build-no-cache-no-pip-update: checkvenv down clean-mypyc-artifacts
 	export IMAGE_TAG=local && \
-	docker build --progress=plain --no-cache -t wycliffeassociates/doc:$${IMAGE_TAG} . && \
-	docker build --progress=plain --no-cache -t wycliffeassociates/doc-ui:$${IMAGE_TAG} ./frontend
+	docker build --progress=plain --no-cache --pull -t wycliffeassociates/doc:$${IMAGE_TAG} . && \
+	docker build --progress=plain --no-cache --pull -t wycliffeassociates/doc-ui:$${IMAGE_TAG} ./frontend
 
 .PHONY: up
 up: checkvenv

--- a/backend/document/config.py
+++ b/backend/document/config.py
@@ -226,6 +226,8 @@ class Settings(BaseSettings):
 
     USE_GIT_CLI: bool = False
 
+    LIMIT_WORDS: bool
+
     LOGGING_CONFIG_FILE_PATH: str = "backend/document/logging_config.yaml"
 
     # Location where resource assets will be downloaded.

--- a/backend/document/domain/model.py
+++ b/backend/document/domain/model.py
@@ -445,7 +445,7 @@ class TWNameContentPair:
 class TWBook(NamedTuple):
     """
     A class to hold a list of TWNameContentPair instances and a list
-    of TWUses instances.
+    of TWUse instances.
     """
 
     lang_code: str


### PR DESCRIPTION
Limit TW words when LIMIT_WORDS is true in .env. Later we may take this further and make LIMIT_WORDS a parameter of an incoming document request and expose its value as a toggle in the UI, but for now it is configurable at the backend API via .env file.