### PR TITLE
No need to limit the height to 7rem.

### DIFF
--- a/frontend/src/routes/settings/GenerateDocument.svelte
+++ b/frontend/src/routes/settings/GenerateDocument.svelte
@@ -206,7 +206,7 @@
   }
 </script>
 
-<div class="h-28 bg-white pb-4 pt-12">
+<div class="bg-white pb-4 pt-12">
   {#if !generatingDocument || $settingsUpdated}
     {#if ($langCountStore > 0 || $langCountStore <= 2) && $assemblyStrategyKindStore && $bookCountStore > 0 && $resourceTypesCountStore > 0}
       <div class="pb-4">


### PR DESCRIPTION
  The disclaimer causes some odd overflow scrolling once the download button has been hit
<img width="1026" alt="image" src="https://github.com/WycliffeAssociates/DOC/assets/67284402/b9346dbc-64d3-454b-867b-5338dae57872">
and after
<img width="1495" alt="image" src="https://github.com/WycliffeAssociates/DOC/assets/67284402/4ae7fecc-3871-4a64-8e4a-701e30aa9b07">

@PurpleGuitar 