### PR TITLE
Palette fixes

### DIFF
--- a/frontend/src/routes/resource_types/+page.svelte
+++ b/frontend/src/routes/resource_types/+page.svelte
@@ -200,7 +200,7 @@
                       value={lang0ResourceTypeAndName}
                       class="checkbox-target checkbox-style"
                     />
-                    <span class="text-primary-content pl-1 text-xl"
+                    <span class="pl-1 text-xl"
                       >{getResourceTypeName(lang0ResourceTypeAndName)}</span
                     >
                   </li>
@@ -238,7 +238,7 @@
                       value={lang1ResourceTypeAndName}
                       class="checkbox-target checkbox-style"
                     />
-                    <span class="text-primary-content pl-1 text-xl"
+                    <span class="pl-1 text-xl"
                       >{getResourceTypeName(lang1ResourceTypeAndName)}</span
                     >
                   </li>
@@ -286,7 +286,7 @@
                       value={lang0ResourceTypeAndName}
                       class="checkbox-target checkbox-style"
                     />
-                    <span class="text-primary-content pl-1"
+                    <span class="pl-1"
                       >{getResourceTypeName(lang0ResourceTypeAndName)}</span
                     >
                   </li>
@@ -319,7 +319,7 @@
                       value={lang1ResourceTypeAndName}
                       class="checkbox-target checkbox-style"
                     />
-                    <span class="text-primary-content pl-1 text-xl"
+                    <span class="pl-1 text-xl"
                       >{getResourceTypeName(lang1ResourceTypeAndName)}</span
                     >
                   </li>

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -11,7 +11,6 @@ module.exports = {
   plugins: [require('daisyui')],
   daisyui: {
     themes: ["light"], // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
-    // themes: false, // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
     // darkTheme: "dark", // name of one of the included themes for dark mode
     // base: true, // applies background color and foreground color for root element by default
     // styled: true, // include daisyUI colors and design decisions for all components

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -10,7 +10,8 @@ module.exports = {
   },
   plugins: [require('daisyui')],
   daisyui: {
-    themes: false, // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
+    themes: ["light"], // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
+    // themes: false, // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
     // darkTheme: "dark", // name of one of the included themes for dark mode
     // base: true, // applies background color and foreground color for root element by default
     // styled: true, // include daisyUI colors and design decisions for all components


### PR DESCRIPTION
This PR is comprised of two changes:

Temporarily force light mode all the time by setting theme options to `["light"]`.  This prevents dark mode from being activated, even if the user's desktop is in dark mode, because only some elements were in dark mode, and checkboxes looked checked even when they were not checked.  (See image below for how the UI looked before the change.)

![image](https://github.com/WycliffeAssociates/DOC/assets/1095575/f576f02d-dfb3-484f-aa0a-7b808e2ff69b)

Temporarily remove "text-primary-content" class from resource list.  In light theme mode, it caused the resources to be a faint blue, hard to read.  (See image below for how the UI looked before the change.)

![image](https://github.com/WycliffeAssociates/DOC/assets/1095575/f7a4aa3c-d57c-4560-982a-802fcb165ae2)

Now light mode is always active, checkboxes look normal, and the resource text is easy to read. (See image below for how the UI looks now.)

![image](https://github.com/WycliffeAssociates/DOC/assets/1095575/fded00ae-bc87-4011-86d7-ee47eac4ecc4)
