### PR TITLE
USFM-Tools no longer relies on cython

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -28,7 +28,7 @@ setuptools
 termcolor
 toolz
 trio
-usfm_tools @ https://github.com/linearcombination/USFM-Tools/archive/refs/tags/0.0.9.zip
+usfm_tools @ https://github.com/linearcombination/USFM-Tools/archive/refs/tags/0.1.3.zip
 uvicorn
 weasyprint
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -310,7 +310,7 @@ urllib3==2.2.1
     #   botocore
     #   requests
     #   types-requests
-usfm-tools @ https://github.com/linearcombination/USFM-Tools/archive/refs/tags/0.0.9.zip
+usfm-tools @ https://github.com/linearcombination/USFM-Tools/archive/refs/tags/0.1.3.zip
     # via -r ./backend/requirements.in
 uvicorn[standard]==0.28.0
     # via


### PR DESCRIPTION
Switched linearcombination/USFM-Tools build system from setup/cython to hatchling for development speed at no cost to performance (Cython used to make things quicker, but with Python 3.12 being faster, the performance gain of cythonization is now small). This commit points to the new github release of USFM-Tools.