### PR TITLE
Fix nginx trailing slash issue (with redirect)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,7 +9,7 @@ server {
   root /app/build/client;
 
   location / {
-    try_files $uri $uri/ @sveltekit;
+    $uri $uri/ @sveltekit;
   }
 
   location @sveltekit {
@@ -20,7 +20,7 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Sendfile-Type X-Accel-Redirect;
 
-    proxy_pass http://sveltekit-server/;
+    proxy_pass http://sveltekit-server;
     proxy_redirect off;
 
     error_page 502 = @static;


### PR DESCRIPTION
Stop using try_files as it causes a redirect by design. See https://stackoverflow.com/questions/53454974/how-to-get-url-parameter-and-pass-to-proxy-pass-using-nginx