### PR TITLE
Handle control characters in usfm

### DIFF
--- a/backend/document/domain/parsing.py
+++ b/backend/document/domain/parsing.py
@@ -256,6 +256,17 @@ def get_chapter_num(chapter_usfm_text: str) -> int:
     )
 
 
+def remove_null_bytes_and_control_characters(html_content: Optional[str]) -> str:
+    """
+    Remove any NULL bytes and all control characters.
+
+    Some languages' accidentally have ASCI control characters in their
+    USFM. We strip those out as well as the possibility of ASCII NULL
+    bytes.
+    """
+    return re.sub(r"[\x00-\x1F]+", "", html_content) if html_content else ""
+
+
 def usfm_book_content(
     resource_lookup_dto: ResourceLookupDto,
     resource_dir: str,
@@ -276,8 +287,13 @@ def usfm_book_content(
             chapter_html_content = usfm_chapter_html(
                 chapter, resource_lookup_dto, chapter_num
             )
+            cleaned_chapter_html_content = remove_null_bytes_and_control_characters(
+                chapter_html_content
+            )
             usfm_chapters[chapter_num] = USFMChapter(
-                content=chapter_html_content if chapter_html_content else "",
+                content=cleaned_chapter_html_content
+                if cleaned_chapter_html_content
+                else "",
                 verses=None,
             )
     return USFMBook(

--- a/backend/document/stet/stet.py
+++ b/backend/document/stet/stet.py
@@ -354,11 +354,14 @@ def generate_docx_document(
     #     template = filepath.read()
     env = jinja2.Environment(autoescape=True).from_string(template)
     full_html = env.render(data=word_entries)
+    # Remove any NULL bytes and all control characters
+    cleaned_full_html = re.sub(r"[\x00-\x1F]+", "", full_html)
     # logger.debug("full_html: %s", full_html)
     # filepath_ = f"{working_dir}/{lang0_code}_{lang1_code}_stet.html"
     filepath_ = f"{working_dir}/{document_request_key_}.html"
     with open(filepath_, "w", encoding="utf-8") as outfile2:
-        outfile2.write(full_html)
+        outfile2.write(cleaned_full_html)
+
     html_to_docx = HtmlToDocx()
     # docx_filepath = f"{Path(filepath_).stem}.docx"
     html_to_docx.parse_html_file(filepath_, f"{output_dir}/{Path(docx_filepath_).stem}")

--- a/backend/document/stet/stet.py
+++ b/backend/document/stet/stet.py
@@ -354,14 +354,11 @@ def generate_docx_document(
     #     template = filepath.read()
     env = jinja2.Environment(autoescape=True).from_string(template)
     full_html = env.render(data=word_entries)
-    # Remove any NULL bytes and all control characters
-    cleaned_full_html = re.sub(r"[\x00-\x1F]+", "", full_html)
     # logger.debug("full_html: %s", full_html)
     # filepath_ = f"{working_dir}/{lang0_code}_{lang1_code}_stet.html"
     filepath_ = f"{working_dir}/{document_request_key_}.html"
     with open(filepath_, "w", encoding="utf-8") as outfile2:
-        outfile2.write(cleaned_full_html)
-
+        outfile2.write(full_html)
     html_to_docx = HtmlToDocx()
     # docx_filepath = f"{Path(filepath_).stem}.docx"
     html_to_docx.parse_html_file(filepath_, f"{output_dir}/{Path(docx_filepath_).stem}")

--- a/tests/e2e/test_api_stet_docx.py
+++ b/tests/e2e/test_api_stet_docx.py
@@ -33,3 +33,18 @@ def test_en_abu_stet_docx() -> None:
             },
         )
         check_result(response, suffix="docx")
+
+
+@pytest.mark.stet
+@pytest.mark.docx
+def test_en_ln_stet_docx() -> None:
+    with TestClient(app=app, base_url=settings.api_test_url()) as client:
+        response = client.post(
+            "/stet/documents_stet_docx",
+            json={
+                "lang0_code": "en",
+                "lang1_code": "ln",
+                "email_address": settings.TO_EMAIL_ADDRESS,
+            },
+        )
+        check_result(response, suffix="docx")


### PR DESCRIPTION
This handles the STET en + ln (Lingala) case, but will handle others with this same class of source USFM errors.