### PR TITLE
Fix repeated verse issue

### DIFF
--- a/backend/document/stet/stet.py
+++ b/backend/document/stet/stet.py
@@ -315,6 +315,8 @@ def generate_docx_document(
                 and usfm_book_.resource_type_name
                 == resource_type_codes_and_names[lang1_usfm_resource_type]
             ]
+            source_verse_text = ""
+            target_verse_text = ""
             if source_selected_usfm_books:
                 source_selected_usfm_book = source_selected_usfm_books[0]
                 for verse_ref in verse_ref_dto.verse_refs:


### PR DESCRIPTION
Translation Services noted that when rendering the document for English -> Kubu (kvb), some target text verses are repeated.

This was the classic "in a loop not using old value since current value is null". Fixed, as always, with freshly initializing value with empty string so that the value established in the last loop iteration is not used. Why were some verses null? Because the target language, in this case, did not have a particular book or verse available.