### PR TITLE
Remove alphabetization of STET input words

### DIFF
--- a/backend/stet/domain/parser.py
+++ b/backend/stet/domain/parser.py
@@ -142,8 +142,4 @@ def get_word_entry_dtos(
                     keyword.strip() for keyword in row.cells[3].text.split(",")
                 ]
             word_entry_dtos.append(word_entry_dto)
-    # Sort word entry dtos by first word in word list
-    sorted_word_entry_dtos = sorted(
-        word_entry_dtos, key=lambda word_entry_dto: word_entry_dto.words[0]
-    )
-    return sorted_word_entry_dtos, list(set(lang0_book_codes_and_names__))
+    return word_entry_dtos, list(set(lang0_book_codes_and_names__))


### PR DESCRIPTION
TS QA reported that this caused problems with es-419 alphabetization. Likely it needs further QA and modification to alphabetize with localization in mind.