### PR TITLE
Merge data API data with DOC only data

### DIFF
--- a/backend/doc/domain/resource_lookup.py
+++ b/backend/doc/domain/resource_lookup.py
@@ -723,7 +723,8 @@ def add_data_not_supplied_by_data_api(repos_info: list[RepoEntry]) -> list[RepoE
     """
     DOC needs to support some resources which are not supplied by the
     data API so we augment the data returned from the data API to include
-    them here.
+    them here. If a (language code, resource type) pair already exists in
+    repos_info, do not add it again.
     """
 
     def make_entry(url: HttpUrl, resource_type: str, lang: Language) -> RepoEntry:
@@ -774,7 +775,15 @@ def add_data_not_supplied_by_data_api(repos_info: list[RepoEntry]) -> list[RepoE
             en_lang,
         ),
     ]
-    repos_info.extend(extra_entries)
+    existing_pairs = {
+        (entry.content.language.ietf_code, entry.content.resource_type)
+        for entry in repos_info
+    }
+    for entry in extra_entries:
+        key = (entry.content.language.ietf_code, entry.content.resource_type)
+        if key not in existing_pairs:
+            repos_info.append(entry)
+            existing_pairs.add(key)
     return repos_info
 
 

--- a/frontend/tests/e2e/test.ts
+++ b/frontend/tests/e2e/test.ts
@@ -420,3 +420,14 @@ test('test burmese', async ({ page }) => {
   await page.getByText('Use PrinceXml to produce the').click()
   await page.getByRole('button', { name: 'Generate File' }).click()
 })
+
+test('test merge of data API data and DOC only data', async ({ page }) => {
+  await page.goto('http://localhost:8001/')
+  await expect(page.getByRole('main')).toContainText('Bahasa Indonesia (Indonesian)')
+  await page.getByLabel('Bahasa Indonesia (Indonesian').check()
+  await page.getByRole('button', { name: 'Next' }).click()
+  await page.getByText('Matius').click()
+  await page.getByRole('button', { name: 'Next' }).click()
+  await expect(page.locator('body')).toContainText('Bahasa Indonesian Bible')
+  await expect(page.locator('body')).toContainText('Translation Notes')
+})


### PR DESCRIPTION
For certain languages, e.g., id, there is data approved to show on DOC, e.g., ayt, that is not provided by data API. I noticed a bug where sometimes there could be two Indonesian (id) entries on the language page because the data API was returning id data slightly different than what DOC provided (as data returned by data API evolves over time). This commit makes it so that any data from data API for a particular language, resource combo will be preferred over what DOC was merging into the data, that way if the data changes over time, data API wins.