### PR TITLE
Provide option to link to TW word definitions online. Closes #321

### DIFF
--- a/.env
+++ b/.env
@@ -72,12 +72,6 @@ CHECK_ALL_BOOKS_FOR_LANGUAGE=true
 # they all are available by cloning, hence the value false.
 DOWNLOAD_ASSETS=false
 
-# Setting to false will cause interleave by verse layout to put each
-# TW word associated with the verse in a horizontal comma delimited
-# list, otherwise it will put each TW word in a list with one word per
-# line.
-TW_WORD_LIST_VERTICAL=false
-
 # File lock duration when cloning and potentially removing git repos
 LOCK_TIMEOUT_SECONDS=300
 

--- a/backend/doc/config.py
+++ b/backend/doc/config.py
@@ -179,7 +179,6 @@ class Settings(BaseSettings):
     BOOK_NAME_FMT_STR: str = "<h2 class='book-name'>{}</h2>"
     RESOURCE_TYPE_NAME_FMT_STR: str = "<h1 class='book-name'>{}</h1>"
     HR: str = "<hr/>"
-    TW_WORD_LIST_VERTICAL: bool = False
     BIEL_TW_RESOURCE_URL_FMT_STR: str = (
         "<span><a href='https://bibleineverylanguage.org/resources/languages/{}?resource-type=tw'>{}</a></span>"
     )

--- a/backend/doc/config.py
+++ b/backend/doc/config.py
@@ -180,6 +180,10 @@ class Settings(BaseSettings):
     RESOURCE_TYPE_NAME_FMT_STR: str = "<h1 class='book-name'>{}</h1>"
     HR: str = "<hr/>"
     TW_WORD_LIST_VERTICAL: bool = False
+    BIEL_TW_RESOURCE_URL_FMT_STR: str = (
+        "<span><a href='https://bibleineverylanguage.org/resources/languages/{}?resource-type=tw'>{}</a></span>"
+    )
+    LINK_RATHER_THAN_INCLUDE_TW_DEFINITIONS: bool = True
 
     DOWNLOAD_ASSETS: bool = False  # If true then download assets, else clone assets
 

--- a/backend/doc/config.py
+++ b/backend/doc/config.py
@@ -183,6 +183,7 @@ class Settings(BaseSettings):
     BIEL_TW_RESOURCE_URL_FMT_STR: str = (
         "<span><a href='https://bibleineverylanguage.org/resources/languages/{}?resource-type=tw'>{}</a></span>"
     )
+    TW_RESOURCE_URL_FMT_STR: str = "<span><a href='#{}-{}'>{}</a></span>"
     LINK_RATHER_THAN_INCLUDE_TW_DEFINITIONS: bool = True
 
     DOWNLOAD_ASSETS: bool = False  # If true then download assets, else clone assets

--- a/backend/doc/domain/document_generator.py
+++ b/backend/doc/domain/document_generator.py
@@ -559,6 +559,7 @@ def assemble_content(
     tw_books: Sequence[TWBook],
     bc_books: Sequence[BCBook],
     rg_books: Sequence[RGBook],
+    link_rather_than_include_tw_definitions: bool = settings.LINK_RATHER_THAN_INCLUDE_TW_DEFINITIONS,
 ) -> list[DocumentPart]:
     """
     Assemble and return the content from all requested resources according to the
@@ -652,7 +653,11 @@ def assemble_content(
         )
     t1 = time.time()
     logger.info("Time for interleaving document: %s", t1 - t0)
-    if tw_books and not document_request.layout_for_print:
+    if (
+        tw_books
+        and not link_rather_than_include_tw_definitions
+        and not document_request.layout_for_print
+    ):
         t0 = time.time()
         # Add the translation words definition section for each language requested.
         unique_tw_books = filter_unique_by_lang_code(tw_books)

--- a/backend/doc/utils/tw_utils.py
+++ b/backend/doc/utils/tw_utils.py
@@ -183,6 +183,9 @@ def translation_words_content(
     link_rather_than_include_tw_definitions: bool = settings.LINK_RATHER_THAN_INCLUDE_TW_DEFINITIONS,
     resource_type_name_fmt_str: str = settings.RESOURCE_TYPE_NAME_FMT_STR,
     biel_tw_resource_path_fmt_str: str = settings.BIEL_TW_RESOURCE_URL_FMT_STR,
+    tw_resource_path_fmt_str: str = settings.TW_RESOURCE_URL_FMT_STR,
+    div_open: str = "<div>",
+    div_close: str = "</div>",
 ) -> list[DocumentPart]:
     is_rtl = tw_book and tw_book.lang_direction == LangDirEnum.RTL
     document_parts: list[DocumentPart] = []
@@ -199,7 +202,7 @@ def translation_words_content(
         if link_rather_than_include_tw_definitions:
             document_parts.append(
                 DocumentPart(
-                    content="<div>"
+                    content=div_open
                     + ", ".join(
                         [
                             biel_tw_resource_path_fmt_str.format(
@@ -208,7 +211,7 @@ def translation_words_content(
                             for localized_word, word in unique_words
                         ]
                     )
-                    + "</div>",
+                    + div_close,
                     is_rtl=is_rtl,
                     use_section_visual_separator=False,
                 )
@@ -216,13 +219,18 @@ def translation_words_content(
         else:
             document_parts.append(
                 DocumentPart(
-                    content="<ul>"
+                    content=div_open
                     + ", ".join(
                         [
-                            f"<span><a href='#{tw_book.lang_code}-{word}'>{localized_word}</a></span>"
+                            tw_resource_path_fmt_str.format(
+                                tw_book.lang_code, word, localized_word
+                            )
                             for localized_word, word in unique_words
                         ]
                     )
+                    + div_close,
+                    is_rtl=is_rtl,
+                    use_section_visual_separator=False,
                 )
             )
     return document_parts

--- a/backend/doc/utils/tw_utils.py
+++ b/backend/doc/utils/tw_utils.py
@@ -23,7 +23,6 @@ from doc.domain.model import (
 )
 from doc.utils.list_utils import unique_list_of_strings
 
-
 logger = settings.logger(__name__)
 
 TW = "tw"
@@ -181,8 +180,9 @@ def translation_words_content(
     tw_book: TWBook,
     content: str,
     use_section_visual_separator: bool,
-    tw_word_list_vertical: bool = settings.TW_WORD_LIST_VERTICAL,
+    link_rather_than_include_tw_definitions: bool = settings.LINK_RATHER_THAN_INCLUDE_TW_DEFINITIONS,
     resource_type_name_fmt_str: str = settings.RESOURCE_TYPE_NAME_FMT_STR,
+    biel_tw_resource_path_fmt_str: str = settings.BIEL_TW_RESOURCE_URL_FMT_STR,
 ) -> list[DocumentPart]:
     is_rtl = tw_book and tw_book.lang_direction == LangDirEnum.RTL
     document_parts: list[DocumentPart] = []
@@ -196,17 +196,19 @@ def translation_words_content(
                 use_section_visual_separator=False,
             )
         )
-        if tw_word_list_vertical:
+        if link_rather_than_include_tw_definitions:
             document_parts.append(
                 DocumentPart(
-                    content="<ul>\n"
-                    + "\n".join(
+                    content="<div>"
+                    + ", ".join(
                         [
-                            f"<li><a href='#{tw_book.lang_code}-{word}'>{localized_word}</a></li>"
+                            biel_tw_resource_path_fmt_str.format(
+                                tw_book.lang_code, localized_word
+                            )
                             for localized_word, word in unique_words
                         ]
                     )
-                    + "</ul>",
+                    + "</div>",
                     is_rtl=is_rtl,
                     use_section_visual_separator=False,
                 )
@@ -221,9 +223,6 @@ def translation_words_content(
                             for localized_word, word in unique_words
                         ]
                     )
-                    + "</ul>",
-                    is_rtl=is_rtl,
-                    use_section_visual_separator=False,
                 )
             )
     return document_parts


### PR DESCRIPTION
WIth this PR, online translation word definitions, at BIEL, are linked from each chapter's list of translation words (in the generated document) rather than including TW word definitions in generated documents. 

Please note: The linking does not happen at the individual word level, but rather opens BIEL to the language's TW page which features a drop down to select which specific word. Why? At first we tried to implement per word direct links (for the basic case it works), but there were inconsistencies in how BIEL generates HTML IDs for each word in a way that made it not tractable within budget. It is presumed that the current implementation (in this update), because BIEL offers the dropdown, will suffice. A change back to including translation word definitions in the generated document is still possible if this ever were to change requirements as it is controlled by a program configuration variable. 